### PR TITLE
feat: phase 2 - app router essentials

### DIFF
--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -29,19 +29,22 @@
 
 Чтобы блог перестал выглядеть как CSR-SPA на Next.js.
 
-- [ ] `src/app/error.tsx` — global error boundary
-- [ ] `src/app/not-found.tsx` — 404 страница
-- [ ] `src/app/loading.tsx` + `src/app/[user]/[post]/loading.tsx` — skeleton UI
-- [ ] `src/app/global-error.tsx`
-- [ ] React Query SSR hydration: `HydrationBoundary` + `dehydrate` в `query-provider.tsx`
-- [ ] Префетч на сервере: посты на главной, страница поста
-- [ ] `generateMetadata` для динамических роутов `[user]/[post]/page.tsx`, `[user]/page.tsx` вместо helper'а
-- [ ] OG/Twitter meta в `generateMetadata`
-- [ ] `src/app/sitemap.ts` — SEO
+**PR #2a — базовая обвязка (DONE):**
+- [x] `src/app/error.tsx` — route-level error boundary
+- [x] `src/app/global-error.tsx` — для ошибок в root layout
+- [x] `src/app/not-found.tsx` — 404 страница
+- [x] `src/app/loading.tsx` + `[user]/loading.tsx` + `[user]/[post]/loading.tsx` + `tag/[id]/loading.tsx`
+- [x] React Query SSR-safe `QueryClient` (per-request на сервере, singleton в браузере)
+- [x] SSR hydration для страницы поста: `HydrationBoundary` + `dehydrate` + `prefetchQuery` через `getPostSSR`
+- [x] Типизация params как `Promise<{...}>` в `[user]/[post]/page.tsx`, `[user]/page.tsx`, `tag/[id]/page.tsx` (убрали `any` и eslint-disable)
+
+**PR #2b — SEO:**
+- [ ] `src/app/sitemap.ts` — динамический sitemap из постов API
 - [ ] `src/app/robots.ts`
-- [ ] `src/app/opengraph-image.tsx` — dynamic OG-картинки (`@vercel/og`)
+- [ ] `src/app/[user]/[post]/opengraph-image.tsx` — dynamic OG-картинки (`@vercel/og`)
 - [ ] RSS feed: `src/app/feed.xml/route.ts`
-- [ ] Типизация params: убрать `any` в `src/app/[user]/[post]/page.tsx:1,7,26` и `[user]/page.tsx:1,7,29` (в Next 15 params — это `Promise`)
+- [ ] SSR prefetch для главной и `[user]/page.tsx` (сейчас flash-of-loading)
+- [ ] `notFound()` в server component при отсутствии пользователя/поста (сейчас клиент рендерит ошибку, статус 200)
 - [ ] Миграция Tailwind v3-style config → v4 CSS-first (`@theme` в `globals.css`)
 
 ---

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,8 @@
 import type { NextConfig } from "next";
 
+const API_URL =
+  process.env.NEXT_PUBLIC_API ?? "https://blog-api-prod.notlazy.org";
+
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   transpilePackages: ["@mdxeditor/editor"],
@@ -29,7 +32,7 @@ const nextConfig: NextConfig = {
     return [
       {
         source: "/api/:path*",
-        destination: `${process.env.NEXT_PUBLIC_API}/api/:path*`,
+        destination: `${API_URL}/api/:path*`,
       },
     ];
   },

--- a/src/app/[user]/[post]/loading.tsx
+++ b/src/app/[user]/[post]/loading.tsx
@@ -1,0 +1,5 @@
+import { Loading } from "@/shared/ui/loading";
+
+export default function PostLoading() {
+  return <Loading />;
+}

--- a/src/app/[user]/[post]/page.tsx
+++ b/src/app/[user]/[post]/page.tsx
@@ -1,12 +1,20 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from "@tanstack/react-query";
 import { PostDetailedResponse } from "@/shared/api/openapi";
 import { generateMeta } from "@/shared/lib/head/meta-data";
 import PostPage from "./post-page";
 import { getPostSSR } from "@/features/post/model/get-post.ssr";
 
-export async function generateMetadata({ params }: any) {
+type PageProps = {
+  params: Promise<{ user: string; post: string }>;
+};
+
+export async function generateMetadata({ params }: PageProps) {
   const { post: slug } = await params;
-  const postData: PostDetailedResponse = await getPostSSR(slug);
+  const postData: PostDetailedResponse | null = await getPostSSR(slug);
 
   if (postData) {
     return generateMeta({
@@ -16,14 +24,25 @@ export async function generateMetadata({ params }: any) {
       type: "article",
       url: `/${postData.author.userName}/${postData.slug}`,
     });
-  } else {
-    return generateMeta({
-      title: "Not Found",
-    });
   }
+
+  return generateMeta({
+    title: "Not Found",
+  });
 }
 
-export default async function Page({ params }: any) {
+export default async function Page({ params }: PageProps) {
   const { post: slug } = await params;
-  return <PostPage slug={slug} />;
+
+  const queryClient = new QueryClient();
+  await queryClient.prefetchQuery({
+    queryKey: ["getPostBySlug", slug],
+    queryFn: () => getPostSSR(slug),
+  });
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <PostPage slug={slug} />
+    </HydrationBoundary>
+  );
 }

--- a/src/app/[user]/loading.tsx
+++ b/src/app/[user]/loading.tsx
@@ -1,0 +1,5 @@
+import { Loading } from "@/shared/ui/loading";
+
+export default function UserLoading() {
+  return <Loading />;
+}

--- a/src/app/[user]/page.tsx
+++ b/src/app/[user]/page.tsx
@@ -1,12 +1,15 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { getUserSSR } from "@/features/user/model/get-user.ssr";
 import { UserResponse } from "@/shared/api/openapi";
 import { generateMeta } from "@/shared/lib/head/meta-data";
 import UserPage from "./user-page";
 
-export async function generateMetadata({ params }: any) {
+type PageProps = {
+  params: Promise<{ user: string }>;
+};
+
+export async function generateMetadata({ params }: PageProps) {
   const { user } = await params;
-  const userData: UserResponse = await getUserSSR(user);
+  const userData: UserResponse | null = await getUserSSR(user);
 
   if (userData) {
     return generateMeta({
@@ -19,14 +22,14 @@ export async function generateMetadata({ params }: any) {
       url: `/${userData.userName}`,
       card: "summary",
     });
-  } else {
-    return generateMeta({
-      title: "Not Found",
-    });
   }
+
+  return generateMeta({
+    title: "Not Found",
+  });
 }
 
-export default async function Page({ params }: any) {
+export default async function Page({ params }: PageProps) {
   const { user: userName } = await params;
   return <UserPage userName={userName} />;
 }

--- a/src/app/auth/external-callback/page.tsx
+++ b/src/app/auth/external-callback/page.tsx
@@ -37,7 +37,7 @@ export default function ExternalCallbackPage() {
         }
       } catch (e) {
         console.error("External callback failed", e);
-        window.location.replace("/auth/login?error=external-callback");
+        window.location.replace("/?error=external-callback");
       }
     })();
   }, [queryClient]);

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Button } from "@heroui/react";
+import { useEffect } from "react";
+
+type ErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function Error({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen -mt-16 flex flex-col gap-4 items-center justify-center">
+      <h2 className="text-3xl font-bold">A glitch in the Lazyverse...</h2>
+      <p className="text-gray">{error?.message || "Unknown error"}</p>
+      <div className="flex gap-2">
+        <Button color="primary" variant="flat" onPress={reset}>
+          Try again
+        </Button>
+        <Button variant="light" as="a" href="/">
+          Go home
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect } from "react";
+
+type GlobalErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function GlobalError({ error, reset }: GlobalErrorProps) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          minHeight: "100vh",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: "1rem",
+          fontFamily: "system-ui, sans-serif",
+        }}
+      >
+        <h2 style={{ fontSize: "1.875rem", fontWeight: 800 }}>
+          A glitch in the Lazyverse...
+        </h2>
+        <p>{error?.message || "Unknown error"}</p>
+        <button
+          onClick={reset}
+          style={{
+            padding: "0.5rem 1rem",
+            borderRadius: "0.5rem",
+            border: "1px solid currentColor",
+            background: "transparent",
+            cursor: "pointer",
+          }}
+        >
+          Try again
+        </button>
+      </body>
+    </html>
+  );
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,5 @@
+import { Loading } from "@/shared/ui/loading";
+
+export default function RootLoading() {
+  return <Loading />;
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,15 @@
+import { Button, Link } from "@heroui/react";
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen -mt-16 flex flex-col gap-4 items-center justify-center">
+      <h2 className="text-6xl font-bold">404</h2>
+      <p className="text-gray">
+        Couldn&apos;t find what you were looking for.
+      </p>
+      <Button color="primary" variant="flat" as={Link} href="/">
+        Go home
+      </Button>
+    </div>
+  );
+}

--- a/src/app/tag/[id]/loading.tsx
+++ b/src/app/tag/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { Loading } from "@/shared/ui/loading";
+
+export default function TagLoading() {
+  return <Loading />;
+}

--- a/src/app/tag/[id]/page.tsx
+++ b/src/app/tag/[id]/page.tsx
@@ -1,10 +1,12 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { generateMeta } from "@/shared/lib/head/meta-data";
 import TagPage from "./tag-page";
 import { snakeToTitle } from "@/shared/lib/utils";
 
-export async function generateMetadata({ params }: any) {
+type PageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export async function generateMetadata({ params }: PageProps) {
   const { id: tag } = await params;
   const tagName = snakeToTitle(tag);
 
@@ -15,7 +17,7 @@ export async function generateMetadata({ params }: any) {
   });
 }
 
-export default async function Page({ params }: any) {
+export default async function Page({ params }: PageProps) {
   const { id: tag } = await params;
   return <TagPage tag={tag} />;
 }

--- a/src/shared/providers/query-provider.tsx
+++ b/src/shared/providers/query-provider.tsx
@@ -1,19 +1,41 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+"use client";
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      refetchOnWindowFocus: false,
-      retry: 2,
+import {
+  QueryClient,
+  QueryClientProvider,
+  isServer,
+} from "@tanstack/react-query";
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        refetchOnWindowFocus: false,
+        retry: 2,
+        staleTime: 60 * 1000,
+      },
     },
-  },
-});
+  });
+}
+
+let browserQueryClient: QueryClient | undefined = undefined;
+
+export function getQueryClient() {
+  if (isServer) {
+    return makeQueryClient();
+  }
+
+  if (!browserQueryClient) browserQueryClient = makeQueryClient();
+  return browserQueryClient;
+}
 
 export function ReactQueryProvider({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const queryClient = getQueryClient();
+
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );


### PR DESCRIPTION
                                                                                     
  Summary                                                                              
                                            
  Adds the missing App Router basics (error/not-found/loading), sets up per-request    
  React Query on the server with SSR prefetch for post pages, types dynamic route      
  params correctly for Next 15, and restores a fallback in next.config.ts so the     
  rewrite doesn't depend on Vercel env being configured.                               
                                                            
  Changes                                                                              
                                                                                       
  App Router essentials                                                                
  - src/app/error.tsx — route-level error boundary with retry + home link              
  - src/app/global-error.tsx — fallback for errors in root layout (required, must      
  render its own <html>/<body>)                                                        
  - src/app/not-found.tsx — 404 page (previously unknown URLs rendered the home page)
  - src/app/loading.tsx + src/app/[user]/loading.tsx +                                 
  src/app/[user]/[post]/loading.tsx + src/app/tag/[id]/loading.tsx — Suspense fallbacks
   so navigations show a spinner instead of a blank screen                             
                                          
  React Query SSR                                                                      
  - src/shared/providers/query-provider.tsx — QueryClient is now per-request on the    
  server and singleton in the browser (via isServer check). Previous module-level      
  singleton leaked state across requests on the server.                                
  - Default staleTime: 60s added so hydrated data isn't immediately refetched on mount.
  - src/app/[user]/[post]/page.tsx — server component now prefetchQuerys the post via  
  getPostSSR and wraps the client page in HydrationBoundary with
  dehydrate(queryClient). Eliminates the flash-of-loading on first post render.        
                                                            
  Types                                                                                
  - src/app/[user]/[post]/page.tsx, src/app/[user]/page.tsx, src/app/tag/[id]/page.tsx 
  — params now typed as Promise<{...}> per Next 15 App Router. Removed any and the     
  eslint-disable @typescript-eslint/no-explicit-any pragmas.                           
                                                            
  Hotfix: prod env fallback                                                            
  - next.config.ts — rewrite destination reads process.env.NEXT_PUBLIC_API ?? 
  "https://blog-api-prod.notlazy.org". Without the fallback, Vercel deployments without
   NEXT_PUBLIC_API set produced undefined/api/*, which returned HTML 404s and broke all
   client fetches (Unexpected token '<' JSON parse errors).                            
  - src/app/auth/external-callback/page.tsx — redirect on OAuth error now points to /  
  instead of the nonexistent /auth/login route (login is a modal).                     
                                                                                       
  Deployment notes                                          
                                              
  - No new required env vars. Fallbacks cover everything.                              
  - Optional on Vercel (for cleanliness / staging): NEXT_PUBLIC_API,
  NEXT_PUBLIC_SITE_URL, NEXT_PUBLIC_GA_ID.                                             
                                                                                       
  Out of scope (PR #2b)                                                                
                                                                                       
  - sitemap.ts, robots.ts, opengraph-image.tsx, RSS feed    
  - SSR prefetch for home (/) and user page ([user]/page.tsx)                          
  - Proper 404 via notFound() in server components when API returns null (currently
  clients render an error with status 200)                                             
  - Tailwind v3-style config → v4 CSS-first migration     