### PR TITLE
feat(theme): deepen the dark theme — darker bg + translucent panels

### DIFF
--- a/src/app/brand/brand-tab.tsx
+++ b/src/app/brand/brand-tab.tsx
@@ -23,7 +23,7 @@ const LIGHT: Pal = {
   border: "#161616",
 };
 const DARK: Pal = {
-  bg: "#1a1a1a",
+  bg: "#141414",
   fg: "#dcdcdc",
   accent: "#cdff48",
   panel: "#2a2a2a",
@@ -56,7 +56,7 @@ const LIGHT_HEX: Record<string, string> = {
   error: "#b91c1c",
 };
 const DARK_HEX: Record<string, string> = {
-  bg: "#1a1a1a",
+  bg: "#141414",
   fg: "#dcdcdc",
   accent: "#cdff48",
   line: "#e6e6e6",

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -26,7 +26,7 @@ export default function GlobalError({ error, reset }: GlobalErrorProps) {
         style={{
           margin: 0,
           minHeight: "100vh",
-          background: "#1a1a1a",
+          background: "#141414",
           color: "#dcdcdc",
           display: "flex",
           flexDirection: "column",
@@ -94,7 +94,7 @@ export default function GlobalError({ error, reset }: GlobalErrorProps) {
                 height: 36,
                 padding: "0 16px",
                 background: "#cdff48",
-                color: "#1a1a1a",
+                color: "#141414",
                 border: 0,
                 fontFamily: display,
                 fontWeight: 700,

--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -21,7 +21,7 @@ html {
    canvas) so the html bg follows the theme. `data-theme` is "neo" for neo, so an
    attribute selector would miss it and leave the page light. */
 html.dark {
-  background-color: #1a1a1a; /* --m-bg, dark */
+  background-color: #141414; /* --m-bg, dark */
 }
 
 /* Interactive elements always get the pointer cursor (browsers default

--- a/src/assets/styles/tailwind.css
+++ b/src/assets/styles/tailwind.css
@@ -65,52 +65,50 @@
   --m-error: #b91c1c;
 }
 /* `.dark` now lives on <html> (layout inline script + ThemeProvider), so this
-   reaches page scopes AND body-level portals (toasts, modals) alike. */
+   reaches page scopes AND body-level portals (toasts, modals) alike.
+   `--m-card`/`--m-panel` are TRANSLUCENT (the dark #232323 / #2a2a2a at 0.70
+   alpha): composited over the opaque `--m-bg #141414` they read a touch DARKER
+   than a solid fill (~#1e1e1e / ~#232323), so every card/band sinks INTO the
+   canvas instead of sitting on top of it — the look that already shipped in neo,
+   now the baseline for dark too. `--m-bg` stays opaque (the dropdown console +
+   modals use `bg-[var(--m-bg)]`, so they stay fully solid); overlays reset to
+   solid below. neo (whose <html> also carries `.dark`) inherits all of this and
+   only adds the rain bleed. */
 .dark .mono-scope,
 .dark .mono-portal {
-  --m-bg: #1a1a1a;
+  --m-bg: #141414;
   --m-fg: #dcdcdc;
   --m-accent: #cdff48;
   --m-line: #e6e6e6;
-  --m-panel: #2a2a2a;
-  --m-card: #232323;
+  --m-panel: rgba(42, 42, 42, 0.7);
+  --m-card: rgba(35, 35, 35, 0.7);
   --m-muted: #9a9a9a;
   --m-muted2: #7a7a7a;
   --m-dim: #383838;
   --m-error: #ff6b6b;
 }
 
-/* neo — the third theme ("Matrix"). It is the dark theme PLUS this layer: neo
-   always boots `.dark` + `.neo` (set pre-paint), so it inherits the `.dark`
-   tokens above and overrides on TOP:
-   1. Page roots (`.mono-scope`) drop their `bg-[var(--m-bg)]` to transparent so
-      the fixed Matrix-rain drape shows through the whole canvas. The header
-      wrapper is also a `.mono-scope` but carries no bg, so this is a no-op there.
-   2. The `--m-card` / `--m-panel` surface tokens go more translucent (the dark
-      #232323 / #2a2a2a at 0.70 alpha) so EVERY card/band surface (post byline
-      band, home/profile stat bands, hero, feed cards, menu hover) gets a strong,
-      cohesive rain bleed. `--m-bg` stays opaque, so the dropdown console + the
-      modals (`bg-[var(--m-bg)]`) stay fully solid and readable. Text (`--m-fg`
-      #dcdcdc) over a 0.70 #232323 card composited over the dim rain stays well
-      above AA on the dark canvas. */
-html.neo .mono-scope {
-  background-color: transparent;
-}
-html.neo .mono-scope,
-html.neo .mono-portal {
-  --m-card: rgba(35, 35, 35, 0.7);
-  --m-panel: rgba(42, 42, 42, 0.7);
-}
 /* …but OVERLAYS must stay OPAQUE — dropdowns/menus (`role="menu"`), selects
    (`role="listbox"`) and the editor (`.milkdown` — toolbar + popovers read
    `--m-card`/`--m-panel` directly or via `--crepe-color-surface`). Content
-   scrolls behind them, so the translucent rain bleed turns their text
-   unreadable. Reset the surface tokens to their SOLID dark values on them. */
-html.neo [role="menu"],
-html.neo [role="listbox"],
-html.neo .milkdown {
+   scrolls behind them, so the translucency turns their text unreadable. Reset
+   the surface tokens to their SOLID dark values. Applies to dark AND neo (neo's
+   <html> also carries `.dark`). */
+html.dark [role="menu"],
+html.dark [role="listbox"],
+html.dark .milkdown {
   --m-card: #232323;
   --m-panel: #2a2a2a;
+}
+
+/* neo — the third theme ("Matrix"). It is the dark theme PLUS the rain: neo
+   always boots `.dark` + `.neo` (set pre-paint), so it inherits the dark tokens
+   above (incl. the translucent card/panel) and only drops the page-root bg to
+   transparent so the fixed Matrix-rain drape bleeds through the whole canvas.
+   The header wrapper is also a `.mono-scope` but carries no bg, so that's a
+   no-op there. */
+html.neo .mono-scope {
+  background-color: transparent;
 }
 
 /* Cover crop modal — tint react-advanced-cropper's chrome to the Brutalist-Mono

--- a/src/features/arcade/snake/model/engine.ts
+++ b/src/features/arcade/snake/model/engine.ts
@@ -238,7 +238,7 @@ function sampleTwitch(p: number): number {
  * is dark-tuned, so the board just stays this gray everywhere.) The head's
  * direction notch is punched back to this same gray.
  */
-const BOARD_BG = "#1a1a1a";
+const BOARD_BG = "#141414";
 /** Snake head / fresh body — the lime accent (`--m-accent`, dark theme). */
 const ACCENT = "#cdff48";
 /** Tail-end body tint — a dimmer accent so the body reads with subtle depth. */
@@ -261,7 +261,7 @@ export const RABBIT_WHITE = "#e6e6e6";
 const RABBIT_RED = "#ff6b6b";
 /**
  * Faint cell grid — a SEMI-TRANSPARENT white so it adapts to whatever theme bg
- * shows through the transparent canvas (dark `--m-bg #1a1a1a`, neo's slightly
+ * shows through the transparent canvas (dark `--m-bg #141414`, neo's slightly
  * different shade + rain bleed, light) instead of a fixed `#333` that only
  * suited one field. The low alpha keeps it quiet during active play (it must
  * not compete with the snake); the overlay-wash reduction (see `<SnakeBoard>`)
@@ -546,7 +546,7 @@ function killerColor(ch: string): string | null {
  * the creature's FRONT; the rounded `.MMMMM.` / `..MMM..` chin is at the BOTTOM
  * = the back, where the body trails off). `M` = the creature's body pixel (the
  * bright lime accent — kept identical to the body so head + body read as ONE
- * creature, and so the sentinel stays VISIBLE on the dark `#1a1a1a` field; it is
+ * creature, and so the sentinel stays VISIBLE on the dark `#141414` field; it is
  * deliberately NOT black), `R` = a RED sensor/eye light (the hazard red — the
  * sentinel's menacing red ocelli), `.` = transparent (the board shows through).
  * The two `R` in row 3 (`MRMMMRM`) + the single `R` in row 4 (`MMMRMMM`) are the

--- a/src/features/arcade/snake/ui/snake-board.tsx
+++ b/src/features/arcade/snake/ui/snake-board.tsx
@@ -10,7 +10,7 @@ import { Confetti } from "./confetti";
  * Overlay scrim — a fixed NEUTRAL-BLACK wash, NOT the theme bg.
  *
  * Why a raw rgba black (not `--m-bg/60`): the canvas field is always the same
- * dark `#1a1a1a` on EVERY theme (the game palette is dark-tuned), but
+ * dark `#141414` on EVERY theme (the game palette is dark-tuned), but
  * `bg-[var(--m-bg)]/60` followed the THEME bg — so on the LIGHT theme it laid a
  * 60%-white film over a dark board and read as a flat washed-out gray (the
  * owner's "a bit off"). A theme-independent low-alpha BLACK instead
@@ -92,7 +92,7 @@ export function SnakeBoard({ api }: { api: SnakeGameApi }) {
       : "Off the board — eat more, grow longer";
 
   // Force the DARK palette on the board + overlays: the canvas field is always the
-  // dark `#1a1a1a` on every theme, so the overlay text/accent must read the
+  // dark `#141414` on every theme, so the overlay text/accent must read the
   // dark-theme `--m-*` (light fg + lime), not the light theme's dark fg (invisible
   // on the dark board). The dark vars are scoped `.dark .mono-scope` — `.dark` on
   // an ANCESTOR — so we wrap the board in a `.dark` div with the board itself the


### PR DESCRIPTION
- dark --m-bg #1a1a1a → #141414 (and its mirrors: the html.dark anti-flash bg in global.scss, the canvas BOARD_BG, global-error's inline page, the /brand swatches) so the page reads a touch deeper
- card/panel surfaces in the dark theme go translucent (the same 0.70-alpha treatment neo already used): composited over the opaque #141414 they read ~#1e1e1e / ~#232323, so cards sink into the canvas. Overlays (menus, selects, the editor) reset to solid so content can't show through them. neo inherits the translucency from .dark and only adds the rain bleed.