### PR TITLE
refactor(user): replace firstName/lastName with a single displayName

### DIFF
--- a/src/app/[user]/page.tsx
+++ b/src/app/[user]/page.tsx
@@ -1,5 +1,6 @@
 import { getPostsByUserNameSSR } from "@/features/post/model/get-posts-by-username.ssr";
 import { generateMeta } from "@/shared/lib/head/meta-data";
+import { displayNameOf } from "@/shared/lib/utils";
 import UserPage from "./user-page";
 
 type PageProps = {
@@ -13,7 +14,7 @@ export async function generateMetadata({ params }: PageProps) {
 
   if (userData) {
     return generateMeta({
-      title: `${userData.firstName} ${userData.lastName}`,
+      title: displayNameOf(userData, user),
       description: `Explore articles and stories shared by ${user}. ${
         userData.biography ? userData.biography : ""
       }`,

--- a/src/app/[user]/user-page.tsx
+++ b/src/app/[user]/user-page.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import { EyeIcon, StarIcon } from "@heroicons/react/24/solid";
-import { UserResponse } from "@/shared/api/openapi";
 import { useUser } from "@/entities/session";
 import { ErrorMessage } from "@/shared/ui/error-message";
 import { Loading } from "@/shared/ui/loading";
@@ -15,11 +14,8 @@ import {
 import { Sparkline, seriesFromMonths } from "@/shared/ui/sparkline";
 import { Label, MatrixText, Avatar, Dot, fmt } from "@/shared/ui";
 import { useInfiniteScroll } from "@/shared/lib/use-infinite-scroll";
-import { formatDate2 } from "@/shared/lib/utils";
+import { displayNameOf, formatDate2 } from "@/shared/lib/utils";
 import { PostCard } from "@/features/post/ui/post-card";
-
-const nameOf = (u?: UserResponse) =>
-  [u?.firstName, u?.lastName].filter(Boolean).join(" ") || u?.userName || "—";
 
 export default function UserPage({ userName }: { userName: string }) {
   const query = usePostsByUserName(userName);
@@ -87,11 +83,15 @@ export default function UserPage({ userName }: { userName: string }) {
       <main className="mx-auto max-w-[1240px] px-10 pb-10">
         {/* Profile header */}
         <section className="flex flex-col gap-10 pt-10 pb-10 sm:flex-row sm:items-center">
-          <Avatar src={user?.avatarUrl} name={nameOf(user)} size="lg" />
+          <Avatar
+            src={user?.avatarUrl}
+            name={displayNameOf(user, "—")}
+            size="lg"
+          />
 
           <div className="min-w-0 flex-1">
             <h1 className="font-display text-[40px] leading-none font-bold tracking-[-0.02em]">
-              {nameOf(user)}
+              {displayNameOf(user, "—")}
             </h1>
             <div className="mt-4 flex flex-wrap items-center gap-2.5 text-[12px] text-[var(--m-muted)]">
               <span className="font-medium text-[var(--m-accent)]">

--- a/src/app/home-page.tsx
+++ b/src/app/home-page.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import Image from "next/image";
 import Link from "next/link";
-import { DisplayPostResponse, UserResponse } from "@/shared/api/openapi";
+import { DisplayPostResponse } from "@/shared/api/openapi";
 import { ErrorMessage } from "@/shared/ui/error-message";
 import { Loading } from "@/shared/ui/loading";
 import { useAllPosts } from "@/features/post/model/use-all-posts";
@@ -19,11 +19,9 @@ import {
   MatrixText,
 } from "@/shared/ui";
 import { useInfiniteScroll } from "@/shared/lib/use-infinite-scroll";
-import { formatDate2 } from "@/shared/lib/utils";
+import { displayNameOf, formatDate2 } from "@/shared/lib/utils";
 import { PostCard } from "@/features/post/ui/post-card";
 
-const nameOf = (u: UserResponse) =>
-  [u.firstName, u.lastName].filter(Boolean).join(" ") || u.userName;
 const catOf = (p: DisplayPostResponse) => p.tags?.[0]?.tag ?? "post";
 const hrefOf = (p: DisplayPostResponse) => `/${p.author.userName}/${p.slug}`;
 // First letter/digit of a title (skips punctuation like "(" so a placeholder
@@ -140,7 +138,7 @@ export default function HomePage() {
                           href={`/${topUser.user.userName}`}
                           className="group block"
                         >
-                          <StatTitle>{nameOf(topUser.user)}</StatTitle>
+                          <StatTitle>{displayNameOf(topUser.user)}</StatTitle>
                         </Link>
                         <div className="mt-4 flex items-center gap-2.5 text-[12px] text-[var(--m-muted)]">
                           <Link

--- a/src/features/auth/ui/auth-modal.tsx
+++ b/src/features/auth/ui/auth-modal.tsx
@@ -316,8 +316,7 @@ function RegisterView({
     try {
       await registerUser({
         email: data.email,
-        firstName: data.firstName,
-        lastName: data.lastName,
+        displayName: data.displayName,
         userName: data.userName,
         password: data.password,
         biography: null,
@@ -340,7 +339,7 @@ function RegisterView({
         eyebrow="// NEW USER"
         title="Create an account"
         titleId={titleId}
-        subtitle="Six fields between you and a comment section. We've seen longer commit messages."
+        subtitle="Five fields between you and a comment section. We've seen longer commit messages."
         onClose={onClose}
       />
 
@@ -376,30 +375,19 @@ function RegisterView({
           />
         </div>
 
-        {/* First + Last name */}
-        <div className="mt-4 grid grid-cols-2 gap-4">
+        {/* Display name — one full-width field spanning the two natural pairs
+            (email/username above, password/confirm below). */}
+        <div className="mt-4">
           <Field
-            id="reg-firstname"
-            label="First name"
+            id="reg-displayname"
+            label="Display name"
             type="text"
-            autoComplete="given-name"
+            autoComplete="name"
             required
-            error={errors.firstName?.message}
-            {...register("firstName", {
-              required: "First Name is required",
-              minLength: { value: 2, message: "At least 2 characters" },
-            })}
-          />
-          <Field
-            id="reg-lastname"
-            label="Last name"
-            type="text"
-            autoComplete="family-name"
-            required
-            error={errors.lastName?.message}
-            {...register("lastName", {
-              required: "Last Name is required",
-              minLength: { value: 2, message: "At least 2 characters" },
+            error={errors.displayName?.message}
+            {...register("displayName", {
+              required: "Display name is required",
+              maxLength: { value: 100, message: "Maximum 100 characters" },
             })}
           />
         </div>

--- a/src/features/comment/model/use-add-comment.ts
+++ b/src/features/comment/model/use-add-comment.ts
@@ -21,8 +21,7 @@ function optimisticComment(
     createdAtUtc: new Date(),
     user: {
       id: user.id ?? "",
-      firstName: user.firstName ?? "",
-      lastName: user.lastName ?? "",
+      displayName: user.displayName ?? "",
       userName: user.userName ?? "",
       avatarUrl: user.avatarUrl ?? null,
     },

--- a/src/features/comment/ui/comment-view.tsx
+++ b/src/features/comment/ui/comment-view.tsx
@@ -7,7 +7,7 @@ import { PencilSquareIcon, TrashIcon } from "@heroicons/react/24/outline";
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import CommentForm from "@/features/comment/ui/comment-form";
-import { formatDate2 } from "@/shared/lib/utils";
+import { displayNameOf, formatDate2 } from "@/shared/lib/utils";
 import ConfirmDeleteModal from "@/shared/ui/confirmation-modal";
 import { Avatar, Dot, Menu, type MenuItem } from "@/shared/ui";
 import { renderCommentMarkdown } from "@/features/comment/lib/comment-markdown";
@@ -20,11 +20,6 @@ interface IProps {
   comment: CommentResponse;
   postId: string;
 }
-
-const nameOf = (u: CommentResponse["user"]) =>
-  [u.firstName, u.lastName].filter(Boolean).join(" ") ||
-  u.userName ||
-  "Unknown";
 
 const CommentView = ({ comment, postId }: IProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -89,15 +84,18 @@ const CommentView = ({ comment, postId }: IProps) => {
       <div className="flex items-center gap-4">
         <Link
           href={`/${handle}`}
-          aria-label={`${nameOf(comment.user)} profile`}
+          aria-label={`${displayNameOf(comment.user)} profile`}
           className="flex-none"
         >
-          <Avatar src={comment.user.avatarUrl} name={nameOf(comment.user)} />
+          <Avatar
+            src={comment.user.avatarUrl}
+            name={displayNameOf(comment.user)}
+          />
         </Link>
 
         <div className="min-w-0">
           <span className="font-display block text-[14px] font-semibold">
-            {nameOf(comment.user)}
+            {displayNameOf(comment.user)}
           </span>
           <div className="mt-1 flex items-center gap-2.5 text-[12px] whitespace-nowrap">
             <Link

--- a/src/features/post/model/use-create-post.ts
+++ b/src/features/post/model/use-create-post.ts
@@ -13,9 +13,7 @@ export const useCreatePost = () => {
 
   return useMutation({
     mutationFn: (data: UpdatePostRequest) =>
-      apiClient.posts.createPost({
-        createPostRequest: { userId: user?.id || "", ...data },
-      }),
+      apiClient.posts.createPost({ createPostRequest: data }),
     onSuccess: (data, variables) => {
       addToastSuccess("Post has been created");
 

--- a/src/features/post/ui/post-view.tsx
+++ b/src/features/post/ui/post-view.tsx
@@ -2,8 +2,8 @@ import type { ReactNode } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { ChatBubbleLeftIcon } from "@heroicons/react/24/solid";
-import { AuthorPostResponse, PostDetailedResponse } from "@/shared/api/openapi";
-import { formatDate2 } from "@/shared/lib/utils";
+import { PostDetailedResponse } from "@/shared/api/openapi";
+import { displayNameOf, formatDate2 } from "@/shared/lib/utils";
 import {
   Avatar,
   Category,
@@ -41,11 +41,6 @@ interface IProps {
   commentsCount?: ReactNode;
 }
 
-const nameOf = (u: AuthorPostResponse) =>
-  [u.firstName, u.lastName].filter(Boolean).join(" ") ||
-  u.userName ||
-  "Unknown";
-
 /** Author tile + name/handle/date + view·like·comment metrics band. */
 function PostByline({
   post,
@@ -61,14 +56,17 @@ function PostByline({
       <div className="mx-auto flex max-w-[780px] flex-wrap items-end gap-x-4 gap-y-4 px-10 py-10">
         <Link
           href={`/${authorHandle}`}
-          aria-label={`${nameOf(post.author)} profile`}
+          aria-label={`${displayNameOf(post.author)} profile`}
           className="self-center"
         >
-          <Avatar src={post.author.avatarUrl} name={nameOf(post.author)} />
+          <Avatar
+            src={post.author.avatarUrl}
+            name={displayNameOf(post.author)}
+          />
         </Link>
         <div className="min-w-0">
           <span className="font-display block truncate text-[14px] font-semibold">
-            {nameOf(post.author)}
+            {displayNameOf(post.author)}
           </span>
           <span className="flex flex-wrap items-center gap-2.5 text-[12px] text-[var(--m-muted)]">
             <Link

--- a/src/features/user/model/use-update-user.ts
+++ b/src/features/user/model/use-update-user.ts
@@ -12,8 +12,7 @@ export const useUpdateUser = (userId: string) => {
       apiClient.users.updateUser({
         id: userId,
         updateUserRequest: {
-          firstName: data.firstName,
-          lastName: data.lastName,
+          displayName: data.displayName,
           userName: data.userName,
           biography: data.biography,
         },

--- a/src/features/user/ui/profile-avatar-zone.tsx
+++ b/src/features/user/ui/profile-avatar-zone.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from "react";
 import { TrashIcon } from "@heroicons/react/24/outline";
 import type { UserResponse } from "@/shared/api/openapi";
 import { Avatar } from "@/shared/ui";
+import { displayNameOf } from "@/shared/lib/utils";
 import { AvatarCropModal } from "./avatar-crop-modal";
 import { useDeleteAvatar } from "../model/use-delete-avatar";
 
@@ -14,9 +15,6 @@ const FILM_BG =
 interface ProfileAvatarZoneProps {
   userData: UserResponse | undefined;
 }
-
-const nameOf = (u?: UserResponse) =>
-  [u?.firstName, u?.lastName].filter(Boolean).join(" ") || u?.userName || "—";
 
 /**
  * Step-1 LEFT panel of the edit-profile card — the avatar equivalent of
@@ -71,7 +69,7 @@ export function ProfileAvatarZone({ userData }: ProfileAvatarZoneProps) {
           >
             <Avatar
               src={userData?.avatarUrl}
-              name={nameOf(userData)}
+              name={displayNameOf(userData, "—")}
               size="lg"
             />
             <span className="absolute inset-0 flex items-center justify-center bg-[var(--m-bg)]/70 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">

--- a/src/features/user/ui/profile-identity-form.tsx
+++ b/src/features/user/ui/profile-identity-form.tsx
@@ -31,8 +31,7 @@ export function ProfileIdentityForm({ userData }: ProfileIdentityFormProps) {
     values: userData
       ? {
           userName: userData.userName ?? "",
-          firstName: userData.firstName ?? "",
-          lastName: userData.lastName ?? "",
+          displayName: userData.displayName ?? "",
           biography: userData.biography ?? null,
         }
       : undefined,
@@ -60,25 +59,15 @@ export function ProfileIdentityForm({ userData }: ProfileIdentityFormProps) {
         })}
       />
 
-      <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <div className="mt-4">
         <Field
-          id="profile-firstname"
-          label="First name"
+          id="profile-displayname"
+          label="Display name"
           required
-          error={errors.firstName?.message}
-          {...register("firstName", {
-            required: "First Name is required",
-            minLength: { value: 2, message: "At least 2 characters" },
-          })}
-        />
-        <Field
-          id="profile-lastname"
-          label="Last name"
-          required
-          error={errors.lastName?.message}
-          {...register("lastName", {
-            required: "Last Name is required",
-            minLength: { value: 2, message: "At least 2 characters" },
+          error={errors.displayName?.message}
+          {...register("displayName", {
+            required: "Display name is required",
+            maxLength: { value: 100, message: "Maximum 100 characters" },
           })}
         />
       </div>

--- a/src/shared/api/openapi/models/AuthorPostResponse.ts
+++ b/src/shared/api/openapi/models/AuthorPostResponse.ts
@@ -26,7 +26,7 @@ export interface AuthorPostResponse {
      */
     id?: string;
     /**
-     *
+     * 
      * @type {string}
      * @memberof AuthorPostResponse
      */

--- a/src/shared/api/openapi/models/AuthorPostResponse.ts
+++ b/src/shared/api/openapi/models/AuthorPostResponse.ts
@@ -26,17 +26,11 @@ export interface AuthorPostResponse {
      */
     id?: string;
     /**
-     * 
+     *
      * @type {string}
      * @memberof AuthorPostResponse
      */
-    firstName?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof AuthorPostResponse
-     */
-    lastName?: string;
+    displayName?: string;
     /**
      * 
      * @type {string}
@@ -81,8 +75,7 @@ export function AuthorPostResponseFromJSONTyped(json: any, ignoreDiscriminator: 
     return {
         
         'id': json['id'] == null ? undefined : json['id'],
-        'firstName': json['firstName'] == null ? undefined : json['firstName'],
-        'lastName': json['lastName'] == null ? undefined : json['lastName'],
+        'displayName': json['displayName'] == null ? undefined : json['displayName'],
         'userName': json['userName'] == null ? undefined : json['userName'],
         'biography': json['biography'] == null ? undefined : json['biography'],
         'avatarUrl': json['avatarUrl'] == null ? undefined : json['avatarUrl'],
@@ -102,8 +95,7 @@ export function AuthorPostResponseToJSONTyped(value?: AuthorPostResponse | null,
     return {
         
         'id': value['id'],
-        'firstName': value['firstName'],
-        'lastName': value['lastName'],
+        'displayName': value['displayName'],
         'userName': value['userName'],
         'biography': value['biography'],
         'avatarUrl': value['avatarUrl'],

--- a/src/shared/api/openapi/models/CreatePostRequest.ts
+++ b/src/shared/api/openapi/models/CreatePostRequest.ts
@@ -39,12 +39,6 @@ export interface CreatePostRequest {
     body: string;
     /**
      * 
-     * @type {string}
-     * @memberof CreatePostRequest
-     */
-    userId: string;
-    /**
-     * 
      * @type {Array<string>}
      * @memberof CreatePostRequest
      */
@@ -76,7 +70,6 @@ export function instanceOfCreatePostRequest(value: object): value is CreatePostR
     if (!('title' in value) || value['title'] === undefined) return false;
     if (!('summary' in value) || value['summary'] === undefined) return false;
     if (!('body' in value) || value['body'] === undefined) return false;
-    if (!('userId' in value) || value['userId'] === undefined) return false;
     if (!('tags' in value) || value['tags'] === undefined) return false;
     if (!('coverUrl' in value) || value['coverUrl'] === undefined) return false;
     return true;
@@ -95,7 +88,6 @@ export function CreatePostRequestFromJSONTyped(json: any, ignoreDiscriminator: b
         'title': json['title'],
         'summary': json['summary'],
         'body': json['body'],
-        'userId': json['userId'],
         'tags': json['tags'] == null ? null : json['tags'],
         'coverUrl': json['coverUrl'],
         'isCoverDisplayed': json['isCoverDisplayed'] == null ? undefined : json['isCoverDisplayed'],
@@ -117,7 +109,6 @@ export function CreatePostRequestToJSONTyped(value?: CreatePostRequest | null, i
         'title': value['title'],
         'summary': value['summary'],
         'body': value['body'],
-        'userId': value['userId'],
         'tags': value['tags'],
         'coverUrl': value['coverUrl'],
         'isCoverDisplayed': value['isCoverDisplayed'],

--- a/src/shared/api/openapi/models/RegisterUserRequest.ts
+++ b/src/shared/api/openapi/models/RegisterUserRequest.ts
@@ -26,7 +26,7 @@ export interface RegisterUserRequest {
      */
     email: string;
     /**
-     *
+     * 
      * @type {string}
      * @memberof RegisterUserRequest
      */

--- a/src/shared/api/openapi/models/RegisterUserRequest.ts
+++ b/src/shared/api/openapi/models/RegisterUserRequest.ts
@@ -26,17 +26,11 @@ export interface RegisterUserRequest {
      */
     email: string;
     /**
-     * 
+     *
      * @type {string}
      * @memberof RegisterUserRequest
      */
-    firstName: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof RegisterUserRequest
-     */
-    lastName: string;
+    displayName: string;
     /**
      * 
      * @type {string}
@@ -62,8 +56,7 @@ export interface RegisterUserRequest {
  */
 export function instanceOfRegisterUserRequest(value: object): value is RegisterUserRequest {
     if (!('email' in value) || value['email'] === undefined) return false;
-    if (!('firstName' in value) || value['firstName'] === undefined) return false;
-    if (!('lastName' in value) || value['lastName'] === undefined) return false;
+    if (!('displayName' in value) || value['displayName'] === undefined) return false;
     if (!('userName' in value) || value['userName'] === undefined) return false;
     if (!('biography' in value) || value['biography'] === undefined) return false;
     if (!('password' in value) || value['password'] === undefined) return false;
@@ -81,8 +74,7 @@ export function RegisterUserRequestFromJSONTyped(json: any, ignoreDiscriminator:
     return {
         
         'email': json['email'],
-        'firstName': json['firstName'],
-        'lastName': json['lastName'],
+        'displayName': json['displayName'],
         'userName': json['userName'],
         'biography': json['biography'],
         'password': json['password'],
@@ -101,8 +93,7 @@ export function RegisterUserRequestToJSONTyped(value?: RegisterUserRequest | nul
     return {
         
         'email': value['email'],
-        'firstName': value['firstName'],
-        'lastName': value['lastName'],
+        'displayName': value['displayName'],
         'userName': value['userName'],
         'biography': value['biography'],
         'password': value['password'],

--- a/src/shared/api/openapi/models/UpdateUserRequest.ts
+++ b/src/shared/api/openapi/models/UpdateUserRequest.ts
@@ -20,17 +20,11 @@ import { mapValues } from '../runtime';
  */
 export interface UpdateUserRequest {
     /**
-     * 
+     *
      * @type {string}
      * @memberof UpdateUserRequest
      */
-    firstName: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof UpdateUserRequest
-     */
-    lastName: string;
+    displayName: string;
     /**
      * 
      * @type {string}
@@ -49,8 +43,7 @@ export interface UpdateUserRequest {
  * Check if a given object implements the UpdateUserRequest interface.
  */
 export function instanceOfUpdateUserRequest(value: object): value is UpdateUserRequest {
-    if (!('firstName' in value) || value['firstName'] === undefined) return false;
-    if (!('lastName' in value) || value['lastName'] === undefined) return false;
+    if (!('displayName' in value) || value['displayName'] === undefined) return false;
     if (!('userName' in value) || value['userName'] === undefined) return false;
     if (!('biography' in value) || value['biography'] === undefined) return false;
     return true;
@@ -66,8 +59,7 @@ export function UpdateUserRequestFromJSONTyped(json: any, ignoreDiscriminator: b
     }
     return {
         
-        'firstName': json['firstName'],
-        'lastName': json['lastName'],
+        'displayName': json['displayName'],
         'userName': json['userName'],
         'biography': json['biography'],
     };
@@ -84,8 +76,7 @@ export function UpdateUserRequestToJSONTyped(value?: UpdateUserRequest | null, i
 
     return {
         
-        'firstName': value['firstName'],
-        'lastName': value['lastName'],
+        'displayName': value['displayName'],
         'userName': value['userName'],
         'biography': value['biography'],
     };

--- a/src/shared/api/openapi/models/UpdateUserRequest.ts
+++ b/src/shared/api/openapi/models/UpdateUserRequest.ts
@@ -20,7 +20,7 @@ import { mapValues } from '../runtime';
  */
 export interface UpdateUserRequest {
     /**
-     *
+     * 
      * @type {string}
      * @memberof UpdateUserRequest
      */

--- a/src/shared/api/openapi/models/UserCommentResponse.ts
+++ b/src/shared/api/openapi/models/UserCommentResponse.ts
@@ -26,17 +26,11 @@ export interface UserCommentResponse {
      */
     id: string;
     /**
-     * 
+     *
      * @type {string}
      * @memberof UserCommentResponse
      */
-    firstName: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof UserCommentResponse
-     */
-    lastName: string;
+    displayName: string;
     /**
      * 
      * @type {string}
@@ -56,8 +50,7 @@ export interface UserCommentResponse {
  */
 export function instanceOfUserCommentResponse(value: object): value is UserCommentResponse {
     if (!('id' in value) || value['id'] === undefined) return false;
-    if (!('firstName' in value) || value['firstName'] === undefined) return false;
-    if (!('lastName' in value) || value['lastName'] === undefined) return false;
+    if (!('displayName' in value) || value['displayName'] === undefined) return false;
     if (!('userName' in value) || value['userName'] === undefined) return false;
     if (!('avatarUrl' in value) || value['avatarUrl'] === undefined) return false;
     return true;
@@ -74,8 +67,7 @@ export function UserCommentResponseFromJSONTyped(json: any, ignoreDiscriminator:
     return {
         
         'id': json['id'],
-        'firstName': json['firstName'],
-        'lastName': json['lastName'],
+        'displayName': json['displayName'],
         'userName': json['userName'],
         'avatarUrl': json['avatarUrl'],
     };
@@ -93,8 +85,7 @@ export function UserCommentResponseToJSONTyped(value?: UserCommentResponse | nul
     return {
         
         'id': value['id'],
-        'firstName': value['firstName'],
-        'lastName': value['lastName'],
+        'displayName': value['displayName'],
         'userName': value['userName'],
         'avatarUrl': value['avatarUrl'],
     };

--- a/src/shared/api/openapi/models/UserCommentResponse.ts
+++ b/src/shared/api/openapi/models/UserCommentResponse.ts
@@ -26,7 +26,7 @@ export interface UserCommentResponse {
      */
     id: string;
     /**
-     *
+     * 
      * @type {string}
      * @memberof UserCommentResponse
      */

--- a/src/shared/api/openapi/models/UserResponse.ts
+++ b/src/shared/api/openapi/models/UserResponse.ts
@@ -32,17 +32,11 @@ export interface UserResponse {
      */
     email?: string;
     /**
-     * 
+     *
      * @type {string}
      * @memberof UserResponse
      */
-    firstName?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof UserResponse
-     */
-    lastName?: string;
+    displayName?: string;
     /**
      * 
      * @type {string}
@@ -88,8 +82,7 @@ export function UserResponseFromJSONTyped(json: any, ignoreDiscriminator: boolea
         
         'id': json['id'] == null ? undefined : json['id'],
         'email': json['email'] == null ? undefined : json['email'],
-        'firstName': json['firstName'] == null ? undefined : json['firstName'],
-        'lastName': json['lastName'] == null ? undefined : json['lastName'],
+        'displayName': json['displayName'] == null ? undefined : json['displayName'],
         'userName': json['userName'] == null ? undefined : json['userName'],
         'biography': json['biography'] == null ? undefined : json['biography'],
         'avatarUrl': json['avatarUrl'] == null ? undefined : json['avatarUrl'],
@@ -110,8 +103,7 @@ export function UserResponseToJSONTyped(value?: UserResponse | null, ignoreDiscr
         
         'id': value['id'],
         'email': value['email'],
-        'firstName': value['firstName'],
-        'lastName': value['lastName'],
+        'displayName': value['displayName'],
         'userName': value['userName'],
         'biography': value['biography'],
         'avatarUrl': value['avatarUrl'],

--- a/src/shared/api/openapi/models/UserResponse.ts
+++ b/src/shared/api/openapi/models/UserResponse.ts
@@ -32,7 +32,7 @@ export interface UserResponse {
      */
     email?: string;
     /**
-     *
+     * 
      * @type {string}
      * @memberof UserResponse
      */

--- a/src/shared/lib/utils.ts
+++ b/src/shared/lib/utils.ts
@@ -4,6 +4,16 @@ import { enUS } from "date-fns/locale";
 export const delay = (seconds: number) =>
   new Promise((resolve) => setTimeout(resolve, seconds * 1000));
 
+/**
+ * Resolve a user's shown name from the single `displayName`, falling back to the
+ * `@userName`, then a caller-chosen placeholder. One model for every byline /
+ * profile / comment surface so the name reads identically everywhere.
+ */
+export const displayNameOf = (
+  user?: { displayName?: string | null; userName?: string | null },
+  fallback = "Unknown"
+): string => user?.displayName?.trim() || user?.userName || fallback;
+
 export const snakeToTitle = (tag: string): string => tag.replace(/_/g, " ");
 export const titleToSnake = (tag: string): string => tag.replace(/\s+/g, "_");
 


### PR DESCRIPTION
Mirrors the backend contract change: the user object and RegisterUserRequest now carry one displayName instead of firstName + lastName.
- openapi models (RegisterUserRequest, UserResponse, UserCommentResponse, AuthorPostResponse, UpdateUserRequest) → displayName
- shared displayNameOf(user) helper (displayName || userName || fallback), replacing the per-surface nameOf helpers (byline, profile, comments, meta)
- register + edit-profile forms: First/Last fields → one Display name field
- add-comment optimistic user + update-user payload → displayName