### PR TITLE
refactor(ui): decouple shared/ui from Next.js 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,13 @@
 # Project rules
 
+## Architecture — Next.js is the SEO head only; everything else is full client
+
+**Next.js serves exactly two roles: (1) the SEO meta head for crawlers & social cards, and (2) the thin routing shell. Nothing else.** Treat the app as a client SPA that happens to be prerendered for its `<head>`.
+
+- **The "head" (the ONLY genuinely server-rendered output):** `generateMetadata` (title · description · `og:image` cover · article-body snippet → meta tags for Google & social-card unfurls), the JSON-LD `Article`, `sitemap.ts`, `feed.xml`, and the meta-only **anonymous** server fetches in the route `page.tsx` files that feed those. That's it.
+- **Everything else is FULL client-side React** — all page content, every component, all data fetching (client components + TanStack Query). Pages render on the client; the server only emits the head. (This is why e.g. the post route renders `PostPageBody` client-side and must NOT server-`notFound()` — see [the draft-preview rule].)
+- **`src/shared/ui` MUST stay framework-agnostic — NO `next/*` bindings.** It's a portable component library (Storybook-able, reusable). Use plain client React instead: **`<img loading="lazy">`** not `next/image` (we run avatars/UGC `unoptimized` anyway), **`<a href>`** not `next/link`, **`React.lazy` + `Suspense`** not `next/dynamic`, plain CSS/`@font-face` not `next/font`. Any `next/*` import that creeps into `shared/ui` is a bug — replace it. (The `app/` / `widgets/` / `features/` layers may still use Next routing — `next/link`, `useRouter` — as the navigation shell; only the head is server-rendered.)
+
 ## Brutalist-Mono design system — ALWAYS follow
 
 The frontend (home / profile / post / auth) uses the "Brutalist Mono" design system. **Apply this on every UI edit and every new feature. Do NOT invent new spacing / size / letter-spacing values — pick from the scale below. If you notice a mismatch while working, flag it and propose the guide-correct value.**

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -98,6 +98,32 @@ const fsdBoundaries = {
   },
 };
 
+/**
+ * `src/shared/ui` is a framework-agnostic component library (Storybook-able,
+ * reusable) — it must NOT bind to Next.js (CLAUDE.md: "Next.js is the SEO head
+ * only; everything else is full client"). Ban every `next/*` import here, and
+ * turn off the Next lint rule that pushes `<Link>` onto a plain `<a>` (the lib
+ * uses plain `<a>` / `<img>` / `React.lazy` instead of next/link/image/dynamic).
+ */
+const sharedUiNextFree = {
+  files: ["src/shared/ui/**/*.{ts,tsx}"],
+  rules: {
+    "no-restricted-imports": [
+      "error",
+      {
+        patterns: [
+          {
+            group: ["next/*"],
+            message:
+              "shared/ui must stay framework-agnostic — no next/* imports. Use <img>/<a>/React.lazy/CSS instead (CLAUDE.md: Next.js is the SEO head only).",
+          },
+        ],
+      },
+    ],
+    "@next/next/no-html-link-for-pages": "off",
+  },
+};
+
 const eslintConfig = [
   {
     ignores: [".next/**", "out/**", "build/**", "next-env.d.ts"],
@@ -105,6 +131,7 @@ const eslintConfig = [
   ...coreWebVitals,
   ...typescript,
   fsdBoundaries,
+  sharedUiNextFree,
 ];
 
 export default eslintConfig;

--- a/src/shared/ui/data-display/avatar.tsx
+++ b/src/shared/ui/data-display/avatar.tsx
@@ -1,4 +1,6 @@
-import Image from "next/image";
+"use client";
+
+import { useState } from "react";
 
 interface AvatarProps {
   /** Avatar image URL; falls back to the initial when absent or broken. */
@@ -18,32 +20,40 @@ const SIZES = {
  * Brutalist-Mono avatar — a square 2px-border tile with the user's photo, or
  * their first initial on the panel surface when no image is set. `sm` (40px) is
  * the byline/comment size; `lg` (128px) is the profile header.
+ *
+ * The initial sits BEHIND the image as a zero-cost placeholder: it shows while
+ * the photo loads (the fixed box already reserves space, so there's no layout
+ * shift) and stays if the photo is missing or fails to load (`onError`). Plain
+ * `<img>`, not next/image — shared/ui is framework-agnostic and the avatar ran
+ * `unoptimized` anyway (arbitrary Azure-blob UGC URLs).
  */
 export function Avatar({ src, name, size = "sm" }: AvatarProps) {
   const { box, letter } = SIZES[size];
   const initial = name.trim().charAt(0).toUpperCase() || "?";
+  const [broken, setBroken] = useState(false);
 
   return (
     <span
-      className="flex shrink-0 items-center justify-center overflow-hidden border-2 border-[var(--m-dim)] bg-[var(--m-panel)] select-none"
+      className="relative flex shrink-0 overflow-hidden border-2 border-[var(--m-dim)] bg-[var(--m-panel)] select-none"
       style={{ width: box, height: box }}
     >
-      {src ? (
-        <Image
+      <span
+        aria-hidden="true"
+        className={`font-display absolute inset-0 flex items-center justify-center font-bold text-[var(--m-muted2)] ${letter}`}
+      >
+        {initial}
+      </span>
+      {src && !broken && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
           src={src}
           alt={name}
           width={box}
           height={box}
-          unoptimized
-          className="size-full object-cover"
+          loading="lazy"
+          onError={() => setBroken(true)}
+          className="absolute inset-0 size-full object-cover"
         />
-      ) : (
-        <span
-          aria-hidden="true"
-          className={`font-display font-bold text-[var(--m-muted2)] ${letter}`}
-        >
-          {initial}
-        </span>
       )}
     </span>
   );

--- a/src/shared/ui/error-message.tsx
+++ b/src/shared/ui/error-message.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { ResponseError } from "@/shared/api/openapi";
-import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useThemeSafe } from "@/shared/providers/theme-providers";
 import { GlitchText } from "@/shared/ui/effects";
@@ -116,12 +115,12 @@ export const ErrorMessage = ({
         ) : null}
 
         <div className="mt-6 flex flex-wrap gap-3">
-          <Link
+          <a
             href="/"
             className={`mono-cta mono-focus inline-flex h-9 items-center justify-center px-4 text-[14px] font-bold tracking-[0.06em]`}
           >
             Go home
-          </Link>
+          </a>
         </div>
       </div>
     </div>

--- a/src/shared/ui/image-cropper-dynamic.tsx
+++ b/src/shared/ui/image-cropper-dynamic.tsx
@@ -1,7 +1,22 @@
-import dynamic from "next/dynamic";
-import { Loading } from "@/shared/ui/feedback/loading";
+"use client";
 
-export const ImageCropper = dynamic(() => import("./image-cropper"), {
-  ssr: false,
-  loading: () => <Loading inline />,
-});
+import { lazy, Suspense } from "react";
+import { Loading } from "@/shared/ui/feedback/loading";
+import type { ImageCropperProps } from "./image-cropper";
+
+const LazyImageCropper = lazy(() => import("./image-cropper"));
+
+/**
+ * Lazily-loaded image cropper — the heavy `react-advanced-cropper` chunk loads
+ * on demand (client-only), so it never weighs down the initial bundle. Plain
+ * `React.lazy` + `Suspense` (not `next/dynamic`) so `shared/ui` stays
+ * framework-agnostic; `"use client"` keeps it off the server like the old
+ * `ssr: false` did.
+ */
+export function ImageCropper(props: ImageCropperProps) {
+  return (
+    <Suspense fallback={<Loading inline />}>
+      <LazyImageCropper {...props} />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
…ture)

shared/ui is a framework-agnostic component library — strip its Next bindings so it stays portable (Storybook-able) and reusable:
- avatar: next/image -> <img loading=lazy>; the initial letter now sits behind the photo as a zero-shift loading/error placeholder (onError -> letter)
- error-message: next/link -> <a>
- image-cropper-dynamic: next/dynamic -> React.lazy + Suspense

Enforce + document: ESLint override bans next/* in shared/ui and turns off the Next page-link rule; CLAUDE.md gains the 'Next.js = SEO head only, everything else is full client' architecture principle.