### PR TITLE
refactor: retire the neo (Matrix) theme — light/dark only + cleanup

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -126,7 +126,14 @@ const sharedUiNextFree = {
 
 const eslintConfig = [
   {
-    ignores: [".next/**", "out/**", "build/**", "next-env.d.ts"],
+    ignores: [
+      ".next/**",
+      "out/**",
+      "build/**",
+      "storybook-static/**",
+      ".claude/**",
+      "next-env.d.ts",
+    ],
   },
   ...coreWebVitals,
   ...typescript,

--- a/src/app/app-providers.tsx
+++ b/src/app/app-providers.tsx
@@ -3,9 +3,8 @@
 import { AuthProvider } from "@/entities/session";
 import { ErrorBoundary } from "@/shared/providers/error-boundary";
 import { ReactQueryProvider } from "@/shared/providers/query-provider";
-import { ThemeProvider } from "@/shared/providers/theme-providers";
+import { ThemeProvider } from "@/shared/ui/theme";
 import { Toaster } from "@/shared/ui/overlays/toaster";
-import { MatrixRain } from "@/shared/ui/effects";
 import { Header } from "@/widgets/header";
 
 export const AppProviders = ({ children }: { children: React.ReactNode }) => {
@@ -18,12 +17,6 @@ export const AppProviders = ({ children }: { children: React.ReactNode }) => {
                 page, so error / 404 / loading states keep navigation too. The
                 `.mono-scope` wrapper gives the fixed chrome the `--m-*` tokens. */}
             <div className="mono-scope">
-              {/* Ambient Matrix-rain backdrop behind every page — fixed, low
-                  opacity, click-through, NEO-MODE ONLY (`mono-rain-bg` is hidden
-                  outside `html.neo` via CSS). In neo the page roots go
-                  transparent (and the card/panel tokens go faintly translucent)
-                  so this drape bleeds through. Reduced-motion safe. */}
-              <MatrixRain className="mono-rain-bg pointer-events-none fixed inset-0 -z-10 opacity-20" />
               <Header />
             </div>
             {children}

--- a/src/app/arcade/follow-the-rabbit/snake-page.tsx
+++ b/src/app/arcade/follow-the-rabbit/snake-page.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import Link from "next/link";
 import { ProtectedRoute } from "@/entities/session";
-import { useTheme } from "@/shared/providers/theme-providers";
-import { GlitchText } from "@/shared/ui/effects";
 import {
   ArcadeHeader,
   SnakeBoard,
@@ -17,6 +13,7 @@ import {
  * Snake Arcade route — LOGIN-ONLY (scores persist per user + the global high
  * score is per-account), so the whole page sits behind {@link ProtectedRoute};
  * the game engine hook only mounts once the viewer is known authenticated.
+ * Open to any theme — sign in and play.
  */
 export default function SnakePage() {
   return (
@@ -27,88 +24,12 @@ export default function SnakePage() {
 }
 
 /**
- * Easter egg: the white rabbit lives in the matrix — the ONLY proper way into
- * the arcade is the neo theme (that's the only theme the header rabbit shows in).
- * So if you're here in ANY other theme — whether you opened the URL directly OR
- * switched away from neo while playing — you're "not the One" and the page
- * glitches into the reject screen until you (re)enter neo. Returns whether to
- * show it.
- *
- * The verdict reads the `html.neo` class (set pre-paint, authoritative) alongside
- * the provider theme, and starts "unknown" (→ no reject), so a neo visitor never
- * flashes the reject screen during the provider's first-paint theme settle.
- */
-function useRejectedFromMatrix(): boolean {
-  const { theme } = useTheme();
-  const [verdict, setVerdict] = useState<"unknown" | "in" | "out">("unknown");
-
-  useEffect(() => {
-    const inMatrix =
-      theme === "neo" || document.documentElement.classList.contains("neo");
-    // Defer the state flip out of the effect body (repo rule: no synchronous
-    // setState inside an effect) — rAF settles it on the next frame.
-    const id = requestAnimationFrame(() => setVerdict(inMatrix ? "in" : "out"));
-    return () => cancelAnimationFrame(id);
-  }, [theme]);
-
-  return verdict === "out";
-}
-
-/**
- * The reject screen — a full-width glitch overlay shown when the player is on the
- * arcade in a non-neo theme. Sits BELOW the header (`top-[var(--m-header-h)]`) so
- * the header bar stays visible, and at a z UNDER the header's own stacking context
- * so the open burger DROPDOWN renders ON TOP of it (you can still flip back to
- * neo from the menu). The game stays mounted under it (the canvas never
- * re-attaches); switching back to neo clears it.
- */
-function NotTheOne() {
-  return (
-    <div
-      className="mono-scope fixed inset-x-0 top-[var(--m-header-h)] bottom-0 z-[calc(var(--m-z-header)_-_1)] flex flex-col justify-center overflow-y-auto bg-[var(--m-bg)] px-10 py-14 text-[var(--m-fg)]"
-      style={{ fontFamily: "var(--font-mono)" }}
-      role="alertdialog"
-      aria-label="Access denied"
-    >
-      <div className="mx-auto w-full max-w-[640px]">
-        <div className="mb-6 flex items-center gap-2.5 text-[11px] leading-none tracking-[0.12em] text-[var(--m-error)]">
-          <span
-            aria-hidden="true"
-            className="inline-block size-2 bg-[var(--m-error)]"
-          />
-          ACCESS DENIED
-        </div>
-
-        <h1 className="font-display text-[32px] leading-[1.04] font-bold tracking-[-0.02em] text-[var(--m-fg)] md:text-[40px]">
-          <GlitchText caret>You are not the One</GlitchText>
-        </h1>
-
-        <p className="mt-4 text-[14px] leading-[1.6] text-[var(--m-muted)]">
-          {"The system doesn't recognize you. Honestly, neither do we."}
-        </p>
-
-        <div className="mt-6 flex flex-wrap items-center gap-3">
-          <Link
-            href="/"
-            className={`mono-cta mono-focus inline-flex h-9 items-center justify-center px-4 text-[14px] font-bold tracking-[0.06em]`}
-          >
-            Go home
-          </Link>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-/**
  * The arcade itself: title block (eyebrow + title + full-width lead) → the stats
  * band (Score / Best / recent-runs chart in our profile/home stats-band format)
  * → the two-pane stage: the board on the LEFT, the `// HIGH SCORES` leaderboard
- * rail on the RIGHT, balanced on the 1240 grid. Being on the arcade in any
- * non-neo theme raises the {@link NotTheOne} reject overlay (easter egg).
+ * rail on the RIGHT, balanced on the 1240 grid.
  */
 function SnakeArcade() {
-  const rejected = useRejectedFromMatrix();
   const { game, board, statsLoading, boardLoading } = useSnakeArcade();
 
   return (
@@ -137,8 +58,6 @@ function SnakeArcade() {
           <SnakeLeaderboard board={board} loading={boardLoading} />
         </div>
       </main>
-
-      {rejected && <NotTheOne />}
     </div>
   );
 }

--- a/src/app/brand/brand-page.tsx
+++ b/src/app/brand/brand-page.tsx
@@ -5,11 +5,13 @@ import { UnderlineTabs } from "@/shared/ui";
 import { BrandTab } from "./brand-tab";
 import { ComponentsTab } from "./components-tab";
 import { LabTab } from "./lab-tab";
+import { GlyphRainTab } from "./glyph-rain-lab";
 
 const TABS = [
   { id: "brand", label: "Brand" },
   { id: "components", label: "Components" },
   { id: "lab", label: "Lab" },
+  { id: "glyph-rain", label: "Glyph Rain" },
 ] as const;
 
 type TabId = (typeof TABS)[number]["id"];
@@ -61,6 +63,8 @@ export default function BrandPage() {
             <ComponentsTab />
           ) : activeTab === "lab" ? (
             <LabTab />
+          ) : activeTab === "glyph-rain" ? (
+            <GlyphRainTab />
           ) : (
             <BrandTab />
           )}

--- a/src/app/brand/brand-tab.tsx
+++ b/src/app/brand/brand-tab.tsx
@@ -23,7 +23,7 @@ const LIGHT: Pal = {
   border: "#161616",
 };
 const DARK: Pal = {
-  bg: "#141414",
+  bg: "#181818",
   fg: "#dcdcdc",
   accent: "#cdff48",
   panel: "#2a2a2a",
@@ -56,7 +56,7 @@ const LIGHT_HEX: Record<string, string> = {
   error: "#b91c1c",
 };
 const DARK_HEX: Record<string, string> = {
-  bg: "#141414",
+  bg: "#181818",
   fg: "#dcdcdc",
   accent: "#cdff48",
   line: "#e6e6e6",

--- a/src/app/brand/components-tab.tsx
+++ b/src/app/brand/components-tab.tsx
@@ -39,6 +39,7 @@ import {
   type SelectOption,
 } from "@/shared/ui";
 import { Callout } from "@/shared/ui/prose";
+import { GlitchText, MatrixText } from "@/shared/ui/effects";
 import {
   Sparkline,
   buildMonthlySeries,
@@ -758,6 +759,30 @@ export function ComponentsTab() {
               </State>
             </div>
           </Panel>
+        </Section>
+
+        <Section
+          index="14"
+          title="TEXT FX"
+          intro="Base text-effect primitives. GlitchText (jitter + accent/error chromatic ghosts — the error-page headline) auto-beats on its own; MatrixText decodes a string from scrambled glyphs and loops. Both are theme-aware and hold a single static frame under reduced-motion."
+        >
+          <div className="grid grid-cols-1 gap-7 lg:grid-cols-2">
+            <Panel caption="// GLITCHTEXT — auto beat">
+              <State caption="jitter + accent/error ghosts (error pages)">
+                <span className="font-display text-[32px] leading-none font-bold tracking-[-0.02em] text-[var(--m-fg)]">
+                  <GlitchText>Glitch</GlitchText>
+                </span>
+              </State>
+            </Panel>
+            <Panel caption="// MATRIXTEXT — decode loop">
+              <State caption="scrambled → resolved · respects reduced-motion">
+                <MatrixText
+                  text="// SIGNAL SENT ... NO REPLY YET"
+                  className="mono-label"
+                />
+              </State>
+            </Panel>
+          </div>
         </Section>
       </div>
 

--- a/src/app/brand/glyph-rain-lab.tsx
+++ b/src/app/brand/glyph-rain-lab.tsx
@@ -886,7 +886,7 @@ const HRAIN_VARIANTS: HRainVariant[] = [
   },
   {
     key: "8 · SMALL + FAST",
-    note: "Smaller dense bits, faster streams — busier, more Matrix.",
+    note: "Smaller dense bits, faster streams — busier, denser.",
     props: {
       glyphs: BIN,
       track: 9,
@@ -1040,9 +1040,9 @@ export function GlyphRainVariantsSection() {
 
   return (
     <Section
-      index="03"
+      index="01"
       title="GLYPH-RAIN — EXPERIMENTS"
-      intro="Our own falling-glyph effect, distanced from The Matrix (0/1, not katakana). 1–6 a grey-LANES fade take; 7–11 a Matrix-style RAIN turned 90° (white-head streams flow horizontally, random speed/direction); 12–16 the SAME falling top→bottom (classic vertical), with knobs for trail / density / opacity. Hit Fullscreen on any box to see it on the whole screen (Esc / click to exit)."
+      intro="Our own falling-glyph backdrop — binary 0/1 in our colour + mono font, a data shimmer of its own. 1–6 a grey-LANES fade take; 7–11 horizontal streams (white head, fading trail, random speed/direction); 12–16 the same falling top→bottom (vertical), with knobs for trail / density / opacity. Hit Fullscreen on any box to see it on the whole screen (Esc / click to exit)."
     >
       <div className="grid grid-cols-1 gap-7 md:grid-cols-2">
         {VARIANTS.map((v) => box(v.key, v.note, <GlyphFade {...v.props} />))}
@@ -1055,5 +1055,30 @@ export function GlyphRainVariantsSection() {
       </div>
       {fs && <FullscreenRain onClose={() => setFs(null)}>{fs}</FullscreenRain>}
     </Section>
+  );
+}
+
+/** The Glyph Rain tab — masthead + the experiments. */
+export function GlyphRainTab() {
+  return (
+    <>
+      <div className="text-[11px] tracking-[0.12em] text-[var(--m-accent)]">
+        {"// NOT LAZY — GLYPH RAIN"}
+      </div>
+      <h1 className="font-display mt-7 text-[40px] leading-none font-bold tracking-[-0.02em]">
+        Glyph Rain
+      </h1>
+      <p className="mt-5 text-[14px] leading-[1.7] text-[var(--m-muted)]">
+        Our own falling-glyph backdrop — binary 0/1 in the live accent + the
+        mono font, a data shimmer of its own. Several directions below (grey
+        lanes, horizontal streams, vertical fall); each can be opened
+        Fullscreen. Theme follows the header toggle; everything degrades under
+        reduced-motion.
+      </p>
+
+      <div className="mt-10">
+        <GlyphRainVariantsSection />
+      </div>
+    </>
   );
 }

--- a/src/app/brand/glyph-rain-lab.tsx
+++ b/src/app/brand/glyph-rain-lab.tsx
@@ -1,0 +1,1059 @@
+"use client";
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { Section, Panel } from "./_helpers";
+
+/* ------------------------------------------------------------------ *
+ * Experimental glyph-fade — LAB / preview ONLY. Horizontal LANES: each
+ * row is a filled very-dark-grey track (height = `track`) separated by a
+ * black `gap`. Inside each lane a line of bits blinks (fade in → hold →
+ * fade at random cells, lane kept ~half-lit), bit-flipping + a faint glow.
+ * Monospace digits sized to fill the lane, evenly spaced. Horizontal (vs
+ * The Matrix's vertical columns). Not the effect's final home.
+ * ------------------------------------------------------------------ */
+
+type Surface = "black" | "theme";
+type ColorMode = "accent" | "dim";
+
+const FADE_FPS_MS = 1000 / 30;
+const REDUCED = "(prefers-reduced-motion: reduce)";
+/** Canvas can't read `var(--font-mono)`; use a real monospace family so the
+ *  size + advance are honoured (equal-width = even spacing). */
+const MONO = 'ui-monospace, "JetBrains Mono", "Courier New", monospace';
+
+function hexToRgb(hex: string): [number, number, number] {
+  const h = hex.replace("#", "").trim();
+  const n =
+    h.length === 3
+      ? h
+          .split("")
+          .map((c) => c + c)
+          .join("")
+      : h;
+  const int = parseInt(n || "0d0d0d", 16);
+  return [(int >> 16) & 255, (int >> 8) & 255, int & 255];
+}
+
+interface GlyphFadeProps {
+  glyphs: readonly string[];
+  /** Lane height in px — the filled grey track; the glyph is sized to fill it. */
+  track?: number;
+  /** Black gap between lanes in px. */
+  gap?: number;
+  /** Lane grey alpha (a very light tint over black). */
+  trackAlpha?: number;
+  /** Fraction of each LANE lit at once (cap; ~0.5 = half). */
+  fillRatio?: number;
+  /** Alpha change per frame — bigger = faster, snappier ramp. */
+  fadeSpeed?: number;
+  /** Frames a glyph holds at full before it starts fading out. */
+  hold?: number;
+  /** Per-frame chance a HELD glyph swaps to another (bit-flip flicker). */
+  flip?: number;
+  /** Canvas shadowBlur on the glyph (a faint glow). */
+  glow?: number;
+  /** Override the glyph colour (e.g. Nixie orange). Falls back to the accent. */
+  colorHex?: string;
+  /** "black" = screen-black; "theme" = the live --m-bg. */
+  surface?: Surface;
+  color?: ColorMode;
+  className?: string;
+}
+
+type Cell = { a: number; v: number; g: string; life: number };
+
+function GlyphFade({
+  glyphs,
+  track = 16,
+  gap = 6,
+  trackAlpha = 0.05,
+  fillRatio = 0.5,
+  fadeSpeed = 0.12,
+  hold = 7,
+  flip = 0.14,
+  glow = 2,
+  colorHex,
+  surface = "black",
+  color = "accent",
+  className = "",
+}: GlyphFadeProps) {
+  const ref = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = ref.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const pitch = track + gap;
+    // Glyph sized to fill the lane; centred.
+    const fontSize = Math.round(track * 1.1);
+    const font = `${fontSize}px ${MONO}`;
+    let w = 0;
+    let h = 0;
+    let cols = 0;
+    let rows = 0;
+    let colW = 11;
+    let cells: Cell[] = [];
+    let accent = "#cdff48";
+    let dim = "#cdff48";
+    let bg: [number, number, number] = [13, 13, 13];
+    let laneLayer: HTMLCanvasElement | null = null;
+    const at = (r: number, c: number) => cells[r * cols + c];
+    const pick = () => glyphs[Math.floor(Math.random() * glyphs.length)];
+    const baseColor = () => colorHex || (color === "dim" ? dim : accent);
+
+    const read = () => {
+      const cs = getComputedStyle(canvas);
+      const a = cs.getPropertyValue("--m-accent").trim();
+      if (a) accent = a;
+      const m = cs.getPropertyValue("--m-muted2").trim();
+      dim = m || accent;
+      const b = cs.getPropertyValue("--m-bg").trim();
+      bg = surface === "theme" && b ? hexToRgb(b) : [13, 13, 13];
+    };
+
+    const buildLanes = () => {
+      if (trackAlpha <= 0) {
+        laneLayer = null;
+        return;
+      }
+      const oc = document.createElement("canvas");
+      oc.width = w;
+      oc.height = h;
+      const o = oc.getContext("2d");
+      if (!o) {
+        laneLayer = null;
+        return;
+      }
+      o.fillStyle = `rgba(255,255,255,${trackAlpha})`;
+      for (let r = 0; r < rows; r++) {
+        o.fillRect(0, r * pitch, w, track);
+      }
+      laneLayer = oc;
+    };
+
+    const resize = () => {
+      w = canvas.clientWidth || 800;
+      h = canvas.clientHeight || 200;
+      canvas.width = w;
+      canvas.height = h;
+      // Even spacing: column pitch = the monospace advance (+1px breathing).
+      ctx.font = font;
+      colW = Math.max(6, Math.round(ctx.measureText("0").width) + 1);
+      cols = Math.max(1, Math.floor(w / colW));
+      rows = Math.max(1, Math.floor(h / pitch));
+      cells = Array.from({ length: cols * rows }, () => ({
+        a: 0,
+        v: 0,
+        g: " ",
+        life: 0,
+      }));
+      read();
+      buildLanes();
+    };
+
+    const frame = () => {
+      ctx.shadowBlur = 0;
+      ctx.globalAlpha = 1;
+      ctx.fillStyle = `rgb(${bg[0]},${bg[1]},${bg[2]})`;
+      ctx.fillRect(0, 0, w, h);
+      if (laneLayer) ctx.drawImage(laneLayer, 0, 0);
+      ctx.font = font;
+      ctx.textBaseline = "middle";
+      const colHex = baseColor();
+      const target = Math.max(1, Math.floor(cols * fillRatio));
+
+      for (let r = 0; r < rows; r++) {
+        let lit = 0;
+        const yMid = r * pitch + track / 2;
+        for (let c = 0; c < cols; c++) {
+          const cell = at(r, c);
+          if (cell.v > 0) {
+            cell.a += cell.v;
+            if (cell.a >= 0.9) {
+              cell.a = 0.9;
+              cell.v = 0;
+              cell.life = hold;
+            }
+          } else if (cell.v < 0) {
+            cell.a += cell.v;
+            if (cell.a <= 0) {
+              cell.a = 0;
+              cell.v = 0;
+              cell.g = " ";
+            }
+          } else if (cell.life > 0) {
+            if (flip && Math.random() < flip) cell.g = pick();
+            cell.life--;
+            if (cell.life <= 0) cell.v = -fadeSpeed;
+          }
+          if (cell.a > 0.02) {
+            lit++;
+            ctx.globalAlpha = cell.a;
+            ctx.fillStyle = colHex;
+            if (glow > 0) {
+              ctx.shadowColor = colHex;
+              ctx.shadowBlur = glow;
+            }
+            ctx.fillText(cell.g, c * colW, yMid);
+            ctx.shadowBlur = 0;
+          }
+        }
+        ctx.globalAlpha = 1;
+        if (lit < target && Math.random() < 0.5) {
+          for (let tries = 0; tries < 4; tries++) {
+            const c = Math.floor(Math.random() * cols);
+            const cell = at(r, c);
+            if (cell.a <= 0.02 && cell.v === 0 && cell.life <= 0) {
+              cell.g = pick();
+              cell.v = fadeSpeed;
+              break;
+            }
+          }
+        }
+      }
+    };
+
+    resize();
+    const ro = new ResizeObserver(resize);
+    ro.observe(canvas);
+    const mq = window.matchMedia(REDUCED);
+    let raf = 0;
+    let last = 0;
+    const loop = (now: number) => {
+      raf = requestAnimationFrame(loop);
+      if (now - last < FADE_FPS_MS) return;
+      last = now;
+      frame();
+    };
+    const start = () => {
+      if (mq.matches) {
+        ctx.shadowBlur = 0;
+        ctx.globalAlpha = 1;
+        ctx.fillStyle = `rgb(${bg[0]},${bg[1]},${bg[2]})`;
+        ctx.fillRect(0, 0, w, h);
+        if (laneLayer) ctx.drawImage(laneLayer, 0, 0);
+        ctx.font = font;
+        ctx.textBaseline = "middle";
+        ctx.fillStyle = baseColor();
+        for (let r = 0; r < rows; r++) {
+          for (let c = 0; c < cols; c++) {
+            if (Math.random() < fillRatio) {
+              ctx.globalAlpha = 0.9;
+              ctx.fillText(pick(), c * colW, r * pitch + track / 2);
+            }
+          }
+        }
+        ctx.globalAlpha = 1;
+        return;
+      }
+      raf = requestAnimationFrame(loop);
+    };
+    const onMq = () => {
+      cancelAnimationFrame(raf);
+      raf = 0;
+      start();
+    };
+    mq.addEventListener("change", onMq);
+    start();
+
+    return () => {
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+      mq.removeEventListener("change", onMq);
+    };
+  }, [
+    glyphs,
+    track,
+    gap,
+    trackAlpha,
+    fillRatio,
+    fadeSpeed,
+    hold,
+    flip,
+    glow,
+    colorHex,
+    surface,
+    color,
+  ]);
+
+  return (
+    <canvas
+      ref={ref}
+      aria-hidden="true"
+      className={`pointer-events-none block size-full ${className}`}
+    />
+  );
+}
+
+/* ---- Variant 2: HORIZONTAL RAIN ---------------------------------- *
+ * The Matrix rain turned 90°: in each grey lane a stream of glyphs flows
+ * LEFT→RIGHT, a bright head with a fading trail behind it.
+ * ------------------------------------------------------------------ */
+
+interface RainHProps {
+  glyphs: readonly string[];
+  /** Row pitch (line height) in px. */
+  track?: number;
+  gap?: number;
+  /** Extra px between glyphs horizontally (on top of the monospace advance). */
+  colGap?: number;
+  /** Head advance in columns per frame (with per-lane jitter). */
+  speed?: number;
+  /** Trail-fade overlay alpha per frame — lower = longer trails. */
+  fade?: number;
+  /** Per-frame chance a trail glyph flickers to a new char (Matrix mutate). */
+  mutate?: number;
+  glow?: number;
+  /** Randomise each lane's flow direction (some →, some ←). */
+  bidir?: boolean;
+  colorHex?: string;
+  color?: ColorMode;
+  className?: string;
+}
+
+/** Bright pale-lime leading head (vs the green trail) — the Matrix "white head". */
+const HEAD = "#eaffc0";
+
+function GlyphRainH({
+  glyphs,
+  track = 12,
+  gap = 7,
+  colGap = 1,
+  speed = 0.5,
+  fade = 0.13,
+  mutate = 0.35,
+  glow = 3,
+  bidir = false,
+  colorHex,
+  color = "accent",
+  className = "",
+}: RainHProps) {
+  const ref = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = ref.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const pitch = track + gap;
+    const fontSize = Math.round(track * 1.1);
+    const font = `${fontSize}px ${MONO}`;
+    let w = 0;
+    let h = 0;
+    let cols = 0;
+    let rows = 0;
+    let colW = 11;
+    // head = current head column (float); seen = last column already painted
+    // green; dir = +1 (flows right) or -1 (flows left).
+    let lanes: { head: number; spd: number; seen: number; dir: number }[] = [];
+    let accent = "#cdff48";
+    let dim = "#cdff48";
+    const pick = () => glyphs[Math.floor(Math.random() * glyphs.length)];
+    const trail = () => colorHex || (color === "dim" ? dim : accent);
+
+    const read = () => {
+      const cs = getComputedStyle(canvas);
+      const a = cs.getPropertyValue("--m-accent").trim();
+      if (a) accent = a;
+      const m = cs.getPropertyValue("--m-muted2").trim();
+      dim = m || accent;
+    };
+
+    const spawn = () => {
+      const dir = bidir && Math.random() < 0.5 ? -1 : 1;
+      const head =
+        dir === 1
+          ? -Math.random() * cols * 0.8 - 1
+          : cols + Math.random() * cols * 0.8 + 1;
+      return {
+        head,
+        // Wide per-lane speed spread — some lanes crawl, some race.
+        spd: speed * (0.3 + Math.random() * 1.5),
+        seen: dir === 1 ? Math.floor(head) - 1 : Math.ceil(head) + 1,
+        dir,
+      };
+    };
+
+    const resize = () => {
+      w = canvas.clientWidth || 800;
+      h = canvas.clientHeight || 200;
+      canvas.width = w;
+      canvas.height = h;
+      ctx.font = font;
+      colW = Math.max(6, Math.round(ctx.measureText("0").width) + colGap);
+      cols = Math.max(1, Math.floor(w / colW));
+      rows = Math.max(1, Math.floor(h / pitch));
+      lanes = Array.from({ length: rows }, spawn);
+      read();
+      ctx.fillStyle = "rgb(13,13,13)";
+      ctx.fillRect(0, 0, w, h);
+    };
+
+    const frame = () => {
+      // Trail fade — the Matrix technique: dim the whole frame toward black so
+      // older glyphs decay; we only paint the head + newly-passed cells.
+      ctx.shadowBlur = 0;
+      ctx.globalAlpha = 1;
+      ctx.fillStyle = `rgba(13,13,13,${fade})`;
+      ctx.fillRect(0, 0, w, h);
+      ctx.font = font;
+      ctx.textBaseline = "middle";
+      const green = trail();
+
+      for (let r = 0; r < rows; r++) {
+        const lane = lanes[r];
+        const yMid = r * pitch + track / 2;
+        lane.head += lane.spd * lane.dir;
+        const hc = Math.floor(lane.head);
+        // Paint the columns the head just passed in green (the trail behind it).
+        if (lane.dir === 1) {
+          while (lane.seen < hc - 1) {
+            lane.seen++;
+            if (lane.seen >= 0 && lane.seen < cols) {
+              ctx.globalAlpha = 1;
+              ctx.fillStyle = green;
+              ctx.fillText(pick(), lane.seen * colW, yMid);
+            }
+          }
+        } else {
+          while (lane.seen > hc + 1) {
+            lane.seen--;
+            if (lane.seen >= 0 && lane.seen < cols) {
+              ctx.globalAlpha = 1;
+              ctx.fillStyle = green;
+              ctx.fillText(pick(), lane.seen * colW, yMid);
+            }
+          }
+        }
+        // The bright head, redrawn each frame so it stays lit + glows.
+        if (hc >= 0 && hc < cols) {
+          ctx.globalAlpha = 1;
+          ctx.fillStyle = HEAD;
+          if (glow > 0) {
+            ctx.shadowColor = green;
+            ctx.shadowBlur = glow;
+          }
+          ctx.fillText(pick(), hc * colW, yMid);
+          ctx.shadowBlur = 0;
+        }
+        // Flicker a random trail glyph (behind the head) back to life.
+        if (Math.random() < mutate) {
+          const c = hc - lane.dir * (2 + Math.floor(Math.random() * 12));
+          if (c >= 0 && c < cols) {
+            ctx.globalAlpha = 0.7;
+            ctx.fillStyle = green;
+            ctx.fillText(pick(), c * colW, yMid);
+          }
+        }
+        if (
+          (lane.dir === 1 && hc - 1 > cols + 14) ||
+          (lane.dir === -1 && hc + 1 < -14)
+        ) {
+          Object.assign(lane, spawn());
+        }
+      }
+      ctx.globalAlpha = 1;
+    };
+
+    resize();
+    const ro = new ResizeObserver(resize);
+    ro.observe(canvas);
+    const mq = window.matchMedia(REDUCED);
+    let raf = 0;
+    let last = 0;
+    const loop = (now: number) => {
+      raf = requestAnimationFrame(loop);
+      if (now - last < FADE_FPS_MS) return;
+      last = now;
+      frame();
+    };
+    const start = () => {
+      if (mq.matches) {
+        ctx.shadowBlur = 0;
+        ctx.globalAlpha = 1;
+        ctx.fillStyle = "rgb(13,13,13)";
+        ctx.fillRect(0, 0, w, h);
+        ctx.font = font;
+        ctx.textBaseline = "middle";
+        ctx.fillStyle = trail();
+        for (let r = 0; r < rows; r++) {
+          for (let c = 0; c < cols; c++) {
+            if (Math.random() < 0.12) {
+              ctx.globalAlpha = 0.8;
+              ctx.fillText(pick(), c * colW, r * pitch + track / 2);
+            }
+          }
+        }
+        ctx.globalAlpha = 1;
+        return;
+      }
+      raf = requestAnimationFrame(loop);
+    };
+    const onMq = () => {
+      cancelAnimationFrame(raf);
+      raf = 0;
+      start();
+    };
+    mq.addEventListener("change", onMq);
+    start();
+
+    return () => {
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+      mq.removeEventListener("change", onMq);
+    };
+  }, [
+    glyphs,
+    track,
+    gap,
+    colGap,
+    speed,
+    fade,
+    mutate,
+    glow,
+    bidir,
+    colorHex,
+    color,
+  ]);
+
+  return (
+    <canvas
+      ref={ref}
+      aria-hidden="true"
+      className={`pointer-events-none block size-full ${className}`}
+    />
+  );
+}
+
+/* ---- Variant 3: VERTICAL RAIN ------------------------------------ *
+ * The same trick but falling TOP→BOTTOM — i.e. the classic Matrix rain,
+ * with our 0/1 glyphs. Here to gauge how close it reads to the film.
+ * ------------------------------------------------------------------ */
+
+interface RainVProps {
+  glyphs: readonly string[];
+  /** Glyph size in px. */
+  track?: number;
+  /** Extra px between glyph COLUMNS (on top of the monospace advance). */
+  colGap?: number;
+  /** Extra px between glyph ROWS (line spacing). */
+  rowGap?: number;
+  /** Fall speed (cols/frame base, with wide per-stream jitter). */
+  speed?: number;
+  /** TRAIL length — the per-frame fade-to-black alpha. LOWER = longer trail. */
+  fade?: number;
+  /** Per-frame chance a trail glyph flickers to a new char (brighter blip). */
+  mutate?: number;
+  /** shadowBlur glow on the head. */
+  glow?: number;
+  /** Overall opacity of the whole rain (0–1). */
+  opacity?: number;
+  /** Fraction of columns carrying a stream (0–1; lower = sparser). */
+  density?: number;
+  /** Head (leading glyph) colour — the bright tip. */
+  headHex?: string;
+  /** Trail colour override (else the live accent). */
+  colorHex?: string;
+  color?: ColorMode;
+  className?: string;
+}
+
+function GlyphRainV({
+  glyphs,
+  track = 11,
+  colGap = 8,
+  rowGap = 3,
+  speed = 1.15,
+  fade = 0.13,
+  mutate = 0.45,
+  glow = 2,
+  opacity = 1,
+  density = 1,
+  headHex = HEAD,
+  colorHex,
+  color = "accent",
+  className = "",
+}: RainVProps) {
+  const ref = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = ref.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const fontSize = Math.round(track * 1.1);
+    const font = `${fontSize}px ${MONO}`;
+    const rowH = track + rowGap;
+    let w = 0;
+    let h = 0;
+    let cols = 0;
+    let rows = 0;
+    let colW = 11;
+    let streams: {
+      head: number;
+      spd: number;
+      seen: number;
+      active: boolean;
+    }[] = [];
+    let accent = "#cdff48";
+    let dim = "#cdff48";
+    const pick = () => glyphs[Math.floor(Math.random() * glyphs.length)];
+    const trail = () => colorHex || (color === "dim" ? dim : accent);
+
+    const read = () => {
+      const cs = getComputedStyle(canvas);
+      const a = cs.getPropertyValue("--m-accent").trim();
+      if (a) accent = a;
+      const m = cs.getPropertyValue("--m-muted2").trim();
+      dim = m || accent;
+    };
+
+    const spawn = () => {
+      const head = -Math.random() * rows * 0.8 - 1;
+      return {
+        head,
+        spd: speed * (0.3 + Math.random() * 1.5),
+        seen: Math.floor(head) - 1,
+        active: Math.random() < density,
+      };
+    };
+
+    const resize = () => {
+      w = canvas.clientWidth || 800;
+      h = canvas.clientHeight || 200;
+      canvas.width = w;
+      canvas.height = h;
+      ctx.font = font;
+      colW = Math.max(6, Math.round(ctx.measureText("0").width) + colGap);
+      cols = Math.max(1, Math.floor(w / colW));
+      rows = Math.max(1, Math.floor(h / rowH));
+      streams = Array.from({ length: cols }, spawn);
+      read();
+      ctx.fillStyle = "rgb(13,13,13)";
+      ctx.fillRect(0, 0, w, h);
+    };
+
+    const frame = () => {
+      ctx.shadowBlur = 0;
+      ctx.globalAlpha = 1;
+      ctx.fillStyle = `rgba(13,13,13,${fade})`;
+      ctx.fillRect(0, 0, w, h);
+      ctx.font = font;
+      ctx.textBaseline = "top";
+      const green = trail();
+
+      for (let c = 0; c < cols; c++) {
+        const s = streams[c];
+        s.head += s.spd;
+        const hr = Math.floor(s.head);
+        if (hr - 1 > rows + 14) {
+          Object.assign(s, spawn());
+          continue;
+        }
+        if (!s.active) continue;
+        const x = c * colW;
+        while (s.seen < hr - 1) {
+          s.seen++;
+          if (s.seen >= 0 && s.seen < rows) {
+            ctx.globalAlpha = opacity;
+            ctx.fillStyle = green;
+            ctx.fillText(pick(), x, s.seen * rowH);
+          }
+        }
+        if (hr >= 0 && hr < rows) {
+          ctx.globalAlpha = opacity;
+          ctx.fillStyle = headHex;
+          if (glow > 0) {
+            ctx.shadowColor = green;
+            ctx.shadowBlur = glow;
+          }
+          ctx.fillText(pick(), x, hr * rowH);
+          ctx.shadowBlur = 0;
+        }
+        if (Math.random() < mutate) {
+          const r = hr - 2 - Math.floor(Math.random() * 12);
+          if (r >= 0 && r < rows) {
+            ctx.globalAlpha = 0.85 * opacity;
+            ctx.fillStyle = green;
+            ctx.fillText(pick(), x, r * rowH);
+          }
+        }
+      }
+      ctx.globalAlpha = 1;
+    };
+
+    resize();
+    const ro = new ResizeObserver(resize);
+    ro.observe(canvas);
+    const mq = window.matchMedia(REDUCED);
+    let raf = 0;
+    let last = 0;
+    const loop = (now: number) => {
+      raf = requestAnimationFrame(loop);
+      if (now - last < FADE_FPS_MS) return;
+      last = now;
+      frame();
+    };
+    const start = () => {
+      if (mq.matches) {
+        ctx.shadowBlur = 0;
+        ctx.globalAlpha = 1;
+        ctx.fillStyle = "rgb(13,13,13)";
+        ctx.fillRect(0, 0, w, h);
+        ctx.font = font;
+        ctx.textBaseline = "top";
+        ctx.fillStyle = trail();
+        for (let c = 0; c < cols; c++) {
+          for (let r = 0; r < rows; r++) {
+            if (Math.random() < 0.12) {
+              ctx.globalAlpha = 0.8;
+              ctx.fillText(pick(), c * colW, r * rowH);
+            }
+          }
+        }
+        ctx.globalAlpha = 1;
+        return;
+      }
+      raf = requestAnimationFrame(loop);
+    };
+    const onMq = () => {
+      cancelAnimationFrame(raf);
+      raf = 0;
+      start();
+    };
+    mq.addEventListener("change", onMq);
+    start();
+
+    return () => {
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+      mq.removeEventListener("change", onMq);
+    };
+  }, [
+    glyphs,
+    track,
+    colGap,
+    rowGap,
+    speed,
+    fade,
+    mutate,
+    glow,
+    opacity,
+    density,
+    headHex,
+    colorHex,
+    color,
+  ]);
+
+  return (
+    <canvas
+      ref={ref}
+      aria-hidden="true"
+      className={`pointer-events-none block size-full ${className}`}
+    />
+  );
+}
+
+const BIN = ["0", "1"] as const;
+const DIGITS = "0123456789".split("");
+/** Classic Nixie neon-orange. */
+const NIXIE = "#ff7e29";
+
+type Variant = {
+  key: string;
+  note: string;
+  props: Omit<GlyphFadeProps, "className">;
+};
+
+const VARIANTS: Variant[] = [
+  {
+    key: "1 · NIXIE GREEN (bg)",
+    note: "The live neo-bg — small digits, big black gaps between lanes, only ~12% of each lane lit at once, soft glow, green accent. (On the page it's also at low opacity so it never fights the foreground.)",
+    props: {
+      glyphs: DIGITS,
+      track: 10,
+      gap: 12,
+      trackAlpha: 0.05,
+      fillRatio: 0.12,
+      glow: 4,
+      fadeSpeed: 0.07,
+      hold: 30,
+      flip: 0.04,
+    },
+  },
+  {
+    key: "2 · SPARSER",
+    note: "Even fewer active digits at once (~6% of each lane).",
+    props: {
+      glyphs: DIGITS,
+      track: 10,
+      gap: 12,
+      trackAlpha: 0.05,
+      fillRatio: 0.06,
+      glow: 4,
+      fadeSpeed: 0.07,
+      hold: 30,
+      flip: 0.04,
+    },
+  },
+  {
+    key: "3 · BIGGER GAP",
+    note: "16px black gap between the lanes.",
+    props: {
+      glyphs: DIGITS,
+      track: 10,
+      gap: 16,
+      trackAlpha: 0.05,
+      fillRatio: 0.22,
+      glow: 4,
+      fadeSpeed: 0.07,
+      hold: 30,
+      flip: 0.04,
+    },
+  },
+  {
+    key: "4 · DARKER LANES",
+    note: "Lane grey even closer to black.",
+    props: {
+      glyphs: DIGITS,
+      track: 10,
+      gap: 12,
+      trackAlpha: 0.03,
+      fillRatio: 0.22,
+      glow: 4,
+      fadeSpeed: 0.07,
+      hold: 30,
+      flip: 0.04,
+    },
+  },
+  {
+    key: "5 · BINARY",
+    note: "Same look, only 0/1 instead of 0–9.",
+    props: {
+      glyphs: BIN,
+      track: 10,
+      gap: 12,
+      trackAlpha: 0.05,
+      fillRatio: 0.22,
+      glow: 4,
+      fadeSpeed: 0.07,
+      hold: 30,
+      flip: 0.04,
+    },
+  },
+  {
+    key: "6 · NIXIE ORANGE",
+    note: "The warm orange take, for reference (the bg keeps the green).",
+    props: {
+      glyphs: DIGITS,
+      colorHex: NIXIE,
+      track: 10,
+      gap: 12,
+      trackAlpha: 0.05,
+      fillRatio: 0.22,
+      glow: 5,
+      fadeSpeed: 0.07,
+      hold: 30,
+      flip: 0.04,
+    },
+  },
+];
+
+type HRainVariant = {
+  key: string;
+  note: string;
+  props: Omit<RainHProps, "className">;
+};
+
+const HRAIN_VARIANTS: HRainVariant[] = [
+  {
+    key: "7 · H-RAIN (base)",
+    note: "White-head streams flow left→right, green fading trail, glyphs mutating. Speed 0.5, 12px, light glow.",
+    props: {
+      glyphs: BIN,
+      track: 12,
+      gap: 7,
+      speed: 0.5,
+      fade: 0.13,
+      glow: 3,
+      mutate: 0.35,
+    },
+  },
+  {
+    key: "8 · SMALL + FAST",
+    note: "Smaller dense bits, faster streams — busier, more Matrix.",
+    props: {
+      glyphs: BIN,
+      track: 9,
+      gap: 5,
+      speed: 0.75,
+      fade: 0.11,
+      glow: 2,
+      mutate: 0.4,
+    },
+  },
+  {
+    key: "9 · LONG TRAILS",
+    note: "Lower fade → longer trails, the screen reads fuller.",
+    props: {
+      glyphs: BIN,
+      track: 11,
+      gap: 6,
+      speed: 0.55,
+      fade: 0.07,
+      glow: 3,
+      mutate: 0.45,
+    },
+  },
+  {
+    key: "10 · BIG + SLOW",
+    note: "Bigger digits, slower, sparser streams.",
+    props: {
+      glyphs: BIN,
+      track: 16,
+      gap: 8,
+      speed: 0.35,
+      fade: 0.13,
+      glow: 3,
+      mutate: 0.3,
+    },
+  },
+  {
+    key: "11 · RANDOM DIRECTION",
+    note: "Like 8 (small + fast) but each lane picks its own way — some flow →, some ← — and re-randomise on respawn.",
+    props: {
+      glyphs: BIN,
+      track: 9,
+      gap: 5,
+      speed: 0.75,
+      fade: 0.11,
+      glow: 2,
+      mutate: 0.4,
+      bidir: true,
+    },
+  },
+];
+
+type VRainVariant = {
+  key: string;
+  note: string;
+  props: Omit<RainVProps, "className">;
+};
+
+const VRAIN_VARIANTS: VRainVariant[] = [
+  {
+    key: "12 · V-RAIN (bg)",
+    note: "The live neo-bg preset — 0/1 falling top→bottom, white head, medium trail.",
+    props: { glyphs: BIN, speed: 0.95, fade: 0.13 },
+  },
+  {
+    key: "13 · LONG TRAIL",
+    note: "Longer trails (fade 0.06).",
+    props: { glyphs: BIN, speed: 0.95, fade: 0.06 },
+  },
+  {
+    key: "14 · SHORT TRAIL",
+    note: "Short trails (fade 0.24).",
+    props: { glyphs: BIN, speed: 0.95, fade: 0.24 },
+  },
+  {
+    key: "15 · SPARSE",
+    note: "Only ~50% of columns carry a stream (density 0.5).",
+    props: { glyphs: BIN, speed: 0.95, fade: 0.13, density: 0.5 },
+  },
+  {
+    key: "16 · DIM + GREEN HEAD",
+    note: "Dimmer overall (opacity 0.6) + a green head instead of white.",
+    props: {
+      glyphs: BIN,
+      speed: 0.95,
+      fade: 0.13,
+      opacity: 0.6,
+      headHex: "#cdff48",
+    },
+  },
+];
+
+/** Full-viewport takeover for a rain effect — Esc / click to exit. */
+function FullscreenRain({
+  children,
+  onClose,
+}: {
+  children: ReactNode;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey, true);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey, true);
+      document.body.style.overflow = prev;
+    };
+  }, [onClose]);
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Effect fullscreen — press Escape or click to exit"
+      onClick={onClose}
+      className="mono-portal fixed inset-0 z-[var(--m-z-rain)] cursor-pointer bg-black"
+    >
+      <div className="absolute inset-0">{children}</div>
+      <div className="pointer-events-none absolute bottom-10 left-1/2 -translate-x-1/2 text-[11px] tracking-[0.12em] text-[var(--m-accent)] uppercase">
+        Click or press esc to exit
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+export function GlyphRainVariantsSection() {
+  const [fs, setFs] = useState<ReactNode>(null);
+
+  const box = (key: string, note: string, effect: ReactNode) => (
+    <Panel key={key} caption={`// ${key}`}>
+      <div className="relative h-[200px] overflow-hidden border-2 border-[var(--m-dim)] bg-black">
+        {effect}
+        <button
+          type="button"
+          onClick={() => setFs(effect)}
+          className="mono-focus absolute right-3 bottom-3 inline-flex h-7 items-center justify-center border-2 border-[var(--m-accent)] bg-black/50 px-3 text-[11px] font-semibold tracking-[0.12em] text-[var(--m-accent)] uppercase transition-colors hover:bg-[var(--m-accent)] hover:text-black"
+        >
+          Fullscreen
+        </button>
+      </div>
+      <p className="mt-4 text-[12px] leading-[1.6] text-[var(--m-muted)]">
+        {note}
+      </p>
+    </Panel>
+  );
+
+  return (
+    <Section
+      index="03"
+      title="GLYPH-RAIN — EXPERIMENTS"
+      intro="Our own falling-glyph effect, distanced from The Matrix (0/1, not katakana). 1–6 a grey-LANES fade take; 7–11 a Matrix-style RAIN turned 90° (white-head streams flow horizontally, random speed/direction); 12–16 the SAME falling top→bottom (classic vertical), with knobs for trail / density / opacity. Hit Fullscreen on any box to see it on the whole screen (Esc / click to exit)."
+    >
+      <div className="grid grid-cols-1 gap-7 md:grid-cols-2">
+        {VARIANTS.map((v) => box(v.key, v.note, <GlyphFade {...v.props} />))}
+        {HRAIN_VARIANTS.map((v) =>
+          box(v.key, v.note, <GlyphRainH {...v.props} />)
+        )}
+        {VRAIN_VARIANTS.map((v) =>
+          box(v.key, v.note, <GlyphRainV {...v.props} />)
+        )}
+      </div>
+      {fs && <FullscreenRain onClose={() => setFs(null)}>{fs}</FullscreenRain>}
+    </Section>
+  );
+}

--- a/src/app/brand/lab-tab.tsx
+++ b/src/app/brand/lab-tab.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { RevealMark, AsciiDivider } from "@/shared/ui/prose";
 import { MatrixRain, MatrixRainOverlay } from "@/shared/ui/effects";
 import { Section, Panel, Spec, State } from "./_helpers";
-import { GlyphRainVariantsSection } from "./glyph-rain-lab";
 import { addToastSuccess } from "@/shared/lib/toasts";
 
 /* ------------------------------- 01 · rain ------------------------------- */
@@ -129,11 +128,11 @@ export function LabTab() {
         Lab
       </h1>
       <p className="mt-5 text-[14px] leading-[1.7] text-[var(--m-muted)]">
-        The effect primitives — Matrix Rain + the glyph-rain experiments — plus
-        the in-post marks kept for a later lib migration. They react to hover,
-        click or your keyboard, and every animation degrades under
-        reduced-motion. Theme follows the header toggle. (Text FX — GlitchText /
-        MatrixText — now live on the Components tab.)
+        The effect primitives — the Matrix Rain canvas + the in-post marks kept
+        for a later lib migration. They react to hover, click or your keyboard,
+        and every animation degrades under reduced-motion. Theme follows the
+        header toggle. (Text FX — GlitchText / MatrixText — live on the
+        Components tab; the glyph-rain experiments on the Glyph Rain tab.)
       </p>
 
       <div className="mt-7 border-l-2 border-[var(--m-accent)] bg-[var(--m-card)] p-4 text-[14px] leading-[1.6] text-[var(--m-muted)]">
@@ -147,7 +146,6 @@ export function LabTab() {
       <div className="mt-10 flex flex-col gap-10">
         <RainSection onFullscreen={openRain} />
         <PostFxSection />
-        <GlyphRainVariantsSection />
       </div>
 
       <MatrixRainOverlay isOpen={rainOpen} onClose={closeRain} />

--- a/src/app/brand/lab-tab.tsx
+++ b/src/app/brand/lab-tab.tsx
@@ -2,13 +2,9 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { RevealMark, AsciiDivider } from "@/shared/ui/prose";
-import {
-  GlitchText,
-  MatrixRain,
-  MatrixRainOverlay,
-  MatrixText,
-} from "@/shared/ui/effects";
+import { MatrixRain, MatrixRainOverlay } from "@/shared/ui/effects";
 import { Section, Panel, Spec, State } from "./_helpers";
+import { GlyphRainVariantsSection } from "./glyph-rain-lab";
 import { addToastSuccess } from "@/shared/lib/toasts";
 
 /* ------------------------------- 01 · rain ------------------------------- */
@@ -38,42 +34,12 @@ function RainSection({ onFullscreen }: { onFullscreen: () => void }) {
   );
 }
 
-/* ------------------------------ 02 · text fx ------------------------------ */
-
-function TextFxSection() {
-  return (
-    <Section
-      index="02"
-      title="TEXT FX"
-      intro="The base text-effect primitives the rest of the lab sits on. GlitchText (jitter + accent/error chromatic ghosts — the error-page headline) auto-beats on its own; MatrixText decodes a string from scrambled glyphs and loops. Both are theme-aware and hold a single static frame under reduced-motion."
-    >
-      <div className="grid grid-cols-1 gap-7 lg:grid-cols-2">
-        <Panel caption="// GLITCHTEXT — auto beat">
-          <State caption="jitter + accent/error ghosts (error pages)">
-            <span className="font-display text-[32px] leading-none font-bold tracking-[-0.02em] text-[var(--m-fg)]">
-              <GlitchText>Glitch</GlitchText>
-            </span>
-          </State>
-        </Panel>
-        <Panel caption="// MATRIXTEXT — decode loop">
-          <State caption="scrambled → resolved · respects reduced-motion">
-            <MatrixText
-              text="// SIGNAL SENT ... NO REPLY YET"
-              className="mono-label"
-            />
-          </State>
-        </Panel>
-      </div>
-    </Section>
-  );
-}
-
-/* ------------------------------ 03 · post fx ------------------------------ */
+/* ------------------------------ 02 · post fx ------------------------------ */
 
 function PostFxSection() {
   return (
     <Section
-      index="03"
+      index="02"
       title="POST FX"
       intro="The in-article marks kept for a later lib migration — each round-trips as a remark directive and renders here exactly as in the read view. Inline: `:spoiler`, `:strike`. Block: `::divider`. All bounded and reading-safe."
     >
@@ -163,11 +129,11 @@ export function LabTab() {
         Lab
       </h1>
       <p className="mt-5 text-[14px] leading-[1.7] text-[var(--m-muted)]">
-        The effect primitives — Matrix Rain, the glitch beat, the
-        decode/scramble text — plus the in-post marks kept for a later lib
-        migration. They react to hover, click or your keyboard, and every
-        animation degrades under reduced-motion. Theme follows the header
-        toggle.
+        The effect primitives — Matrix Rain + the glyph-rain experiments — plus
+        the in-post marks kept for a later lib migration. They react to hover,
+        click or your keyboard, and every animation degrades under
+        reduced-motion. Theme follows the header toggle. (Text FX — GlitchText /
+        MatrixText — now live on the Components tab.)
       </p>
 
       <div className="mt-7 border-l-2 border-[var(--m-accent)] bg-[var(--m-card)] p-4 text-[14px] leading-[1.6] text-[var(--m-muted)]">
@@ -180,8 +146,8 @@ export function LabTab() {
 
       <div className="mt-10 flex flex-col gap-10">
         <RainSection onFullscreen={openRain} />
-        <TextFxSection />
         <PostFxSection />
+        <GlyphRainVariantsSection />
       </div>
 
       <MatrixRainOverlay isOpen={rainOpen} onClose={closeRain} />

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -26,7 +26,7 @@ export default function GlobalError({ error, reset }: GlobalErrorProps) {
         style={{
           margin: 0,
           minHeight: "100vh",
-          background: "#141414",
+          background: "#181818",
           color: "#dcdcdc",
           display: "flex",
           flexDirection: "column",
@@ -94,7 +94,7 @@ export default function GlobalError({ error, reset }: GlobalErrorProps) {
                 height: 36,
                 padding: "0 16px",
                 background: "#cdff48",
-                color: "#141414",
+                color: "#181818",
                 border: 0,
                 fontFamily: display,
                 fontWeight: 700,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,17 +37,16 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <head>
         {/* Resolve + apply the theme to <html> BEFORE first paint (no
-            light→dark / non-neo→neo flash). MUST be a RAW inline <script> in
-            <head> so it runs SYNCHRONOUSLY during HTML parse — `next/script`
-            `beforeInteractive` loads via Next's loader AFTER first paint, which
-            reintroduces the flash. (Tradeoff: React 19 dev-only logs a
-            "script tag in component" notice on client nav; harmless, prod-clean.)
-            ONE source of truth — `localStorage.theme` ∈ light|dark|neo. light =
-            neither class; dark = `.dark`; neo = `.dark` + `.neo`. Migrates the
-            old build's `neo==='on'` flag to the `neo` theme on first read. */}
+            light→dark flash). MUST be a RAW inline <script> in <head> so it runs
+            SYNCHRONOUSLY during HTML parse — `next/script` `beforeInteractive`
+            loads via Next's loader AFTER first paint, which reintroduces the
+            flash. (Tradeoff: React 19 dev-only logs a "script tag in component"
+            notice on client nav; harmless, prod-clean.) ONE source of truth —
+            `localStorage.theme` ∈ light|dark. light = no class; dark = `.dark`.
+            Stale `neo`/legacy values fall back to the OS preference. */}
         <script
           dangerouslySetInnerHTML={{
-            __html: `(function(){try{var e=document.documentElement;var t=localStorage.getItem('theme');if(localStorage.getItem('neo')==='on'){t='neo';localStorage.setItem('theme','neo');localStorage.removeItem('neo');}if(t!=='light'&&t!=='dark'&&t!=='neo'){t=window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';}e.setAttribute('data-theme',t);e.classList.toggle('dark',t==='dark'||t==='neo');e.classList.toggle('neo',t==='neo');}catch(e){}})();`,
+            __html: `(function(){try{var e=document.documentElement;var t=localStorage.getItem('theme');if(t!=='light'&&t!=='dark'){t=window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';}e.setAttribute('data-theme',t);e.classList.toggle('dark',t==='dark');e.classList.remove('neo');}catch(e){}})();`,
           }}
         />
 

--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -19,7 +19,7 @@ html {
 }
 /* Key on the `.dark` CLASS so the html bg follows the theme. */
 html.dark {
-  background-color: #141414; /* --m-bg, dark */
+  background-color: #181818; /* --m-bg, dark */
 }
 
 /* Interactive elements always get the pointer cursor (browsers default

--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -17,9 +17,7 @@ html {
      block so the header column aligns with the page column under it. */
   scrollbar-gutter: stable;
 }
-/* Key on the `.dark` CLASS (set for BOTH dark and neo — neo extends the dark
-   canvas) so the html bg follows the theme. `data-theme` is "neo" for neo, so an
-   attribute selector would miss it and leave the page light. */
+/* Key on the `.dark` CLASS so the html bg follows the theme. */
 html.dark {
   background-color: #141414; /* --m-bg, dark */
 }

--- a/src/assets/styles/tailwind.css
+++ b/src/assets/styles/tailwind.css
@@ -194,15 +194,6 @@
    a `prefers-reduced-motion: reduce` fallback that drops the motion to a static
    end-state (the visual stays legible, just stops moving). */
 
-/* Ambient Matrix-rain backdrop — NEO THEME ONLY. The rain (the global drape +
-   the error-page backdrop) is the headline visual of the `neo` theme; outside
-   neo it's hidden so the light/dark themes look exactly as before. neo always
-   carries `.dark` + `.neo` (set pre-paint), so the rain only ever paints on the
-   dark canvas. The `neo` class is set pre-paint, so no flash. */
-html:not(.neo) .mono-rain-bg {
-  display: none;
-}
-
 /* Signal blur (`:spoiler[…]` / RevealMark variant="blur") — a `blur(5px)` span
    in a 2px `--m-dim` box; sharpens to blur(0) on hover/focus and stays sharp
    (focus is sticky via tabindex). Inline, server-safe. */

--- a/src/features/arcade/snake/model/engine.ts
+++ b/src/features/arcade/snake/model/engine.ts
@@ -1,13 +1,13 @@
-import { MATRIX_GLYPHS } from "@/shared/lib/glyphs";
 import type { Cell, Speed } from "./types";
 
 /**
  * RENDER MODE for the snake + rabbits — the ONE switch the owner flips.
  *
- *  - `"glyph"` (DEFAULT): the snake is drawn as a MATRIX-RAIN STREAM of glyphs
- *    bending along its body (bright near-white head → green {@link ACCENT} body
- *    dimming to {@link ACCENT_DIM} at the tail) — the on-theme "Matrix code"
- *    look, see {@link drawSnakeGlyphs}. The rabbits are ALWAYS the bunny-
+ *  - `"glyph"` (DEFAULT): the snake is drawn as a SOLID-SQUARE STREAM — one
+ *    near-full-cell square per body segment, in the segment colour (bright
+ *    near-white head → green {@link ACCENT} body dimming to a STILL-VISIBLE
+ *    {@link ACCENT_DIM} tail) — the on-theme "Matrix code" look, see
+ *    {@link drawSnakeGlyphs}. The rabbits are ALWAYS the bunny-
  *    silhouette pixel SPRITES (owner preference — they read better than glyph
  *    rabbits), independent of this flag.
  *  - `"sprite"`: the ORIGINAL pixel-art look — the grey sentinel head/body/tail
@@ -274,60 +274,27 @@ const GRID_LINE = "rgba(255,255,255,0.01)";
  *  grid so the board's rim always reads as a distinct field boundary. */
 const FRAME_LINE = "rgba(255,255,255,0.22)";
 
-// ---- glyph (matrix-rain) snake palette + cadence (SNAKE_RENDER === "glyph") ----
+// ---- glyph (square-stream) snake palette (SNAKE_RENDER === "glyph") ----
 
 /**
- * GLYPH-MODE colours. The snake is a rain stream, so it goes GREEN — the
- * authentic Matrix-rain palette (the same lime `--m-accent` family the on-page
- * `MatrixRain` uses), NOT the sprite mode's grey sentinel. The HEAD is the
- * bright leading glyph (near-white, like a rain column's head); the body fades
- * head→tail from {@link ACCENT} (bright green) to {@link ACCENT_DIM} (deep
- * green). (Owner note: if you'd rather the stream be GREY to match the sprite
- * sentinel, swap {@link GLYPH_HEAD}/{@link GLYPH_BODY}/{@link GLYPH_TAIL} to
- * `#f4f6f8` / {@link SENTINEL} / {@link SENTINEL_DIM} — a one-line trio swap.)
+ * SQUARE-STREAM colours. The snake is a stream of solid squares in the lime
+ * `--m-accent` family (the same the on-page rain uses), NOT the sprite mode's
+ * grey sentinel. The HEAD square is the bright accent green ({@link GLYPH_BODY});
+ * the body dims toward {@link GLYPH_TAIL} (deep green) AND fades in opacity
+ * head→tail, so the figure is brightest where the creature is "now" and
+ * dissolves into its wake. (Owner note: for a GREY stream, swap
+ * {@link GLYPH_BODY}/{@link GLYPH_TAIL} to {@link SENTINEL}/{@link SENTINEL_DIM}.)
  */
-const GLYPH_HEAD = "#eaffc0"; // near-white lime — the bright rain head
-const GLYPH_BODY = ACCENT; // bright green stream
+const GLYPH_BODY = ACCENT; // bright accent-green head + stream
 const GLYPH_TAIL = ACCENT_DIM; // deep-green tail end
+/** Opacity floor at the tail end (head = 1) — the stream fades into its wake. */
+const GLYPH_TAIL_ALPHA = 0.3;
 /**
- * Glyph cell coverage (fraction of the cell the glyph FONT is sized to). Sized
- * generously so the code reads, but under 1 so adjacent stream cells stay
- * legible as separate characters.
+ * Per-side inset of each body SQUARE, as a fraction of a cell — a small square
+ * centred in its cell (clear gaps between segments so they read as distinct
+ * blocks, not one solid worm). Snapped to the device-pixel grid (no blur).
  */
-const GLYPH_FILL = 0.5;
-/**
- * Faint cell-BACKGROUND wash behind each glyph snake segment (glyph mode only) —
- * a subtle accent-green fill on the cell so the body reads more clearly on the
- * dark {@link BOARD_BG}, WITHOUT competing with the glyphs (which still paint at
- * full strength on top). The wash's OPACITY tapers head→tail: brightest at the
- * head, fading to ~transparent at the tail, so the snake visibly dissolves into
- * its wake (the owner's "from first to last cell the opacity decreases so it
- * fades out").
- *
- *  - {@link GLYPH_BG} is the wash colour (the lime {@link ACCENT}, mirroring
- *    `--m-accent` on the dark theme — the canvas can't read CSS vars).
- *  - {@link GLYPH_BG_HEAD_ALPHA} → {@link GLYPH_BG_TAIL_ALPHA} are the alpha
- *    endpoints, LERPED linearly across the body by each segment's head→tail
- *    position. Head sits at the high end (~0.18), the tail floor is ~0
- *    (transparent), so the fill genuinely fades out.
- *  - The wash fills a slightly INSET rect (a {@link GLYPH_BG_INSET}-cell margin
- *    each side) so the squares read as a soft body trail, not a hard grid of
- *    full cells; the inset is snapped to the device-pixel grid (no blur).
- */
-const GLYPH_BG = ACCENT;
-const GLYPH_BG_HEAD_ALPHA = 0.18;
-const GLYPH_BG_TAIL_ALPHA = 0;
-/** Per-side inset of the wash rect, as a fraction of a cell (keeps the fill off
- *  the grid lines so adjacent segments read as a trail, not a solid block). */
-const GLYPH_BG_INSET = 0.08;
-/**
- * Churn cadence — how many render frames a stream POSITION holds its glyph
- * before re-rolling (the rain flicker). The HEAD re-rolls faster (it's the live
- * leading glyph). Bigger = calmer/more readable; smaller = busier shimmer. Kept
- * slow enough to read, never a strobe. Frozen entirely under reduced motion.
- */
-const GLYPH_CHURN_FRAMES = 16;
-const GLYPH_HEAD_CHURN_FRAMES = 7;
+const GLYPH_BG_INSET = 0.18;
 
 // ---- RED-SPARK ("ouch" / death) particle burst ----
 // Fires on EVERY NEGATIVE grab AND on the KILLER death (nothing else explodes —
@@ -818,21 +785,6 @@ function lerpHex(a: string, b: string, t: number): string {
   const g = Math.round(ag + (bg - ag) * t);
   const bl = Math.round(ab + (bb - ab) * t);
   return `rgb(${r},${g},${bl})`;
-}
-
-/**
- * Deterministic glyph picker for the matrix-rain stream. Hashes the integer
- * inputs (a stream POSITION + a churn epoch, or a rabbit's cell + epoch) into an
- * index of {@link MATRIX_GLYPHS} — same inputs always yield the same glyph, so
- * the shimmer is reproducible (no `Math.random()` strobe, honoring the engine's
- * determinism intent). A cheap xorshift-style integer mix over a 2D-ish key;
- * `>>> 0` keeps it an unsigned 32-bit int before the modulo.
- */
-function glyphFor(a: number, b: number): string {
-  let h = (a * 73856093) ^ (b * 19349663);
-  h = Math.imul(h ^ (h >>> 13), 0x5bd1e995);
-  h ^= h >>> 15;
-  return MATRIX_GLYPHS[(h >>> 0) % MATRIX_GLYPHS.length];
 }
 
 /**
@@ -1479,63 +1431,24 @@ export class SnakeEngine {
     return sampleTwitch(phase / TWITCH_DUR_FRAMES);
   }
 
-  // ---------- glyph (matrix-rain) renderer (SNAKE_RENDER === "glyph") ----------
+  // ---------- glyph (square-stream) renderer (SNAKE_RENDER === "glyph") ----------
 
   /**
-   * Draw ONE matrix glyph centred in cell `at`, in `color`, with an optional
-   * vertical bob (`yOffsetCells`, fraction of a cell — kept for symmetry with the
-   * sprite path's bob). The font is sized to {@link GLYPH_FILL} of the cell and the draw
-   * origin is snapped to the device-pixel grid (the ctx is `dpr`-scaled, so we
-   * snap in device px then divide back) — keeping the glyph from blurring across
-   * a half-pixel boundary even though text isn't a hard pixel grid. `textAlign`/
-   * `textBaseline` are centred so the glyph sits dead-centre regardless of font
-   * metrics.
+   * Paint one snake-body SQUARE for cell `at`, in `color`, at full opacity. A
+   * slightly inset square (a {@link GLYPH_BG_INSET}-cell margin each side) so the
+   * body reads as a stream of distinct squares on the dark {@link BOARD_BG}
+   * rather than one solid block; the inset + box are snapped to the device-pixel
+   * grid so the fill stays crisp (no blur), matching the sprite rasteriser's
+   * discipline. The size is floored to ≥1 device px so the square never rounds
+   * away to nothing at small cell sizes.
    */
-  private drawGlyph(
+  private drawSquare(
     ctx: CanvasRenderingContext2D,
     cell: number,
     dpr: number,
     at: Cell,
-    glyph: string,
     color: string,
-    yOffsetCells = 0
-  ) {
-    const sizeCss = cell * GLYPH_FILL;
-    // Centre of the cell, in device px, snapped to a whole device pixel so the
-    // glyph baseline lands crisply.
-    const cellDev = cell * dpr;
-    const cxDev = Math.round((at.x + 0.5) * cellDev);
-    // `textBaseline:"middle"` centres on the em-box middle, which for these mono
-    // glyphs sits a hair ABOVE the optical centre — nudge down ~6% of a cell so
-    // the glyph reads centred in its square.
-    const cyDev =
-      Math.round((at.y + 0.5 + yOffsetCells) * cellDev) +
-      Math.round(cellDev * 0.06);
-    // The 2D context can't resolve CSS vars (same reason the palette is literal
-    // hex), so `var(--font-mono)` made the whole font string invalid → it was
-    // silently ignored and the weight never applied. Use a literal monospace
-    // stack so the weight actually lands.
-    ctx.font = `800 ${sizeCss}px ui-monospace, "JetBrains Mono", Menlo, monospace`;
-    ctx.textAlign = "center";
-    ctx.textBaseline = "middle";
-    ctx.fillStyle = color;
-    ctx.fillText(glyph, cxDev / dpr, cyDev / dpr);
-  }
-
-  /**
-   * Paint the faint inset cell-BACKGROUND wash behind one glyph snake segment
-   * (glyph mode), at `alpha` (the head→tail-faded opacity). A slightly inset
-   * square of {@link GLYPH_BG} so the body trail reads on the dark field; the
-   * inset + box are snapped to the device-pixel grid so the fill stays crisp
-   * (no blur), matching the sprite rasteriser's discipline. No-op at alpha ≤ 0
-   * (the tail end), so the very end of the snake costs nothing and is invisible.
-   */
-  private drawGlyphBg(
-    ctx: CanvasRenderingContext2D,
-    cell: number,
-    dpr: number,
-    at: Cell,
-    alpha: number
+    alpha = 1
   ) {
     if (alpha <= 0) return;
     const cellDev = cell * dpr;
@@ -1545,64 +1458,36 @@ export class SnakeEngine {
     const sizeDev = Math.round(cellDev) - insetDev * 2;
     if (sizeDev <= 0) return;
     ctx.globalAlpha = alpha;
-    ctx.fillStyle = GLYPH_BG;
+    ctx.fillStyle = color;
     // Device px → CSS px (the ctx is pre-scaled by `dpr`).
     ctx.fillRect(leftDev / dpr, topDev / dpr, sizeDev / dpr, sizeDev / dpr);
     ctx.globalAlpha = 1;
   }
 
   /**
-   * Draw the snake as a MATRIX-RAIN STREAM that follows its body. Each cell is
-   * one glyph; the HEAD is the bright leading glyph ({@link GLYPH_HEAD}) and the
-   * body fades head→tail from {@link GLYPH_BODY} (bright green) to
-   * {@link GLYPH_TAIL} (deep green), so the whole figure reads like a rain
-   * column bent along the path — brightest where the creature is "now", dimming
-   * into its wake.
+   * Draw the snake as a STREAM OF SQUARES that follows its body. The HEAD is a
+   * bright accent-green square ({@link GLYPH_BODY}) at full opacity; toward the
+   * tail the square BOTH dims in colour (lerps to {@link GLYPH_TAIL}, deep green)
+   * AND fades in opacity (down to {@link GLYPH_TAIL_ALPHA}), so the figure is
+   * brightest where the creature is "now" and dissolves into its wake.
    *
-   * Glyph CHURN (the rain flicker): each STREAM POSITION (index from the head,
-   * NOT the moving cell) re-rolls its glyph every {@link GLYPH_CHURN_FRAMES}
-   * render frames; the head re-rolls faster ({@link GLYPH_HEAD_CHURN_FRAMES}).
-   * The glyph is chosen by {@link glyphFor} from `(position, churnEpoch)` — fully
-   * deterministic, so the shimmer is reproducible and never a random strobe.
-   * Seeding by position-from-head (not by board cell) means the pattern reads as
-   * a STABLE stream that flickers in place, the way a rain column does, rather
-   * than scrambling on every move.
-   *
-   * Painted TAIL→HEAD so the brighter near-head glyphs land on top at any
-   * overlap. `animate=false` (reduced motion) freezes the churn to epoch 0 — a
-   * legible STATIC stream, no flicker.
+   * No glyphs, no churn/flicker — every square is a static fill, so the body is
+   * identical with or without animation (nothing to freeze under reduced motion).
+   * Painted TAIL→HEAD so the brighter near-head squares land on top at any overlap.
    */
   private drawSnakeGlyphs(
     ctx: CanvasRenderingContext2D,
     cell: number,
-    dpr: number,
-    animate: boolean
+    dpr: number
   ) {
     const len = this.snake.length;
-    const headEpoch = animate
-      ? Math.floor(this.frame / GLYPH_HEAD_CHURN_FRAMES)
-      : 0;
-    const bodyEpoch = animate ? Math.floor(this.frame / GLYPH_CHURN_FRAMES) : 0;
     for (let i = len - 1; i >= 0; i--) {
       const seg = this.snake[i];
-      // Faint cell-background wash UNDER the glyph, opacity tapering head→tail:
-      // `t` is 0 at the head, 1 at the tail, so the alpha lerps from the bright
-      // head endpoint down to the (transparent) tail floor — the body fades out.
-      // Painted first so the full-strength glyph always lands on top.
+      // `t` is 0 at the head, 1 at the tail.
       const t = len <= 1 ? 0 : i / (len - 1);
-      const bgAlpha =
-        GLYPH_BG_HEAD_ALPHA + (GLYPH_BG_TAIL_ALPHA - GLYPH_BG_HEAD_ALPHA) * t;
-      this.drawGlyphBg(ctx, cell, dpr, seg, bgAlpha);
-      if (i === 0) {
-        // HEAD — bright leading glyph, fast flicker.
-        this.drawGlyph(ctx, cell, dpr, seg, glyphFor(0, headEpoch), GLYPH_HEAD);
-      } else {
-        // Body fades from bright green just behind the head to deep green at the
-        // tail (eased so most of the stream stays clearly green and only the
-        // last cells go dim).
-        const color = lerpHex(GLYPH_BODY, GLYPH_TAIL, t * 0.9);
-        this.drawGlyph(ctx, cell, dpr, seg, glyphFor(i, bodyEpoch), color);
-      }
+      const color = lerpHex(GLYPH_BODY, GLYPH_TAIL, t * 0.9);
+      const alpha = 1 - (1 - GLYPH_TAIL_ALPHA) * t;
+      this.drawSquare(ctx, cell, dpr, seg, color, alpha);
     }
   }
 
@@ -1682,12 +1567,12 @@ export class SnakeEngine {
       else this.drawNegative(ctx, cell, dpr, r.cell, r.rank, animate);
     }
 
-    // Snake — the matrix-rain GLYPH stream (glyph mode) follows the body in one
-    // call (head/body fade + churn handled inside); skip the entire sprite path
-    // below. Returns early after the head + explosion so the sprite head doesn't
+    // Snake — the square stream (glyph mode) follows the body in one call
+    // (head→tail colour gradient handled inside); skip the entire sprite path
+    // below. Returns early after the body + explosion so the sprite head doesn't
     // double-draw.
     if (SNAKE_RENDER === "glyph") {
-      this.drawSnakeGlyphs(ctx, cell, dpr, animate);
+      this.drawSnakeGlyphs(ctx, cell, dpr);
       this.drawExplosion(ctx, cell);
       return;
     }

--- a/src/features/arcade/snake/ui/snake-board.tsx
+++ b/src/features/arcade/snake/ui/snake-board.tsx
@@ -152,7 +152,7 @@ export function SnakeBoard({ api }: { api: SnakeGameApi }) {
                   New record
                 </div>
               ) : (
-                <Eyebrow color="var(--m-error)">{"// GAME OVER, NEO"}</Eyebrow>
+                <Eyebrow color="var(--m-error)">{"// GAME OVER"}</Eyebrow>
               )}
               <div className="font-display text-[46px] leading-none font-bold text-[var(--m-accent)] tabular-nums">
                 {formatScore(state.score)}

--- a/src/shared/providers/theme-providers.tsx
+++ b/src/shared/providers/theme-providers.tsx
@@ -1,3 +1,0 @@
-// Moved to the UI library theme module. This shim keeps existing
-// `@/shared/providers/theme-providers` imports working.
-export * from "@/shared/ui/theme/theme-provider";

--- a/src/shared/ui/error-message.tsx
+++ b/src/shared/ui/error-message.tsx
@@ -2,7 +2,6 @@
 
 import { ResponseError } from "@/shared/api/openapi";
 import { useEffect, useState } from "react";
-import { useThemeSafe } from "@/shared/providers/theme-providers";
 import { GlitchText } from "@/shared/ui/effects";
 import { Console } from "./overlays/console";
 
@@ -40,10 +39,6 @@ export const ErrorMessage = ({
   status?: number;
 }) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  // The root ErrorBoundary fallback renders ABOVE ThemeProvider, so read the
-  // theme defensively (off <html>) instead of throwing when there's no provider.
-  const { theme } = useThemeSafe();
-  const isNeo = theme === "neo";
 
   useEffect(() => {
     const fetchErrorMessage = async () => {
@@ -75,14 +70,9 @@ export const ErrorMessage = ({
   const statusLine =
     status === 404 ? "NOT FOUND · 404" : `RUNTIME EXCEPTION · ${status ?? 500}`;
 
-  // NEO theme swaps the generic error chrome for a Matrix line (ties into the
-  // neo matrix-rain). Same layout/scale — eyebrow + headline + lead all stay in
-  // the ONE opening-transmission scene so it reads cohesive, not stitched.
-  const eyebrowText = isNeo ? "FOLLOW THE WHITE RABBIT" : statusLine;
-  const headline = isNeo ? "The matrix has you…" : "A glitch in the Lazyverse";
-  const lead = isNeo
-    ? "Knock, knock, Neo."
-    : "Error detected. Motivation to fix it: pending.";
+  const eyebrowText = statusLine;
+  const headline = "A glitch in the Lazyverse";
+  const lead = "Error detected. Motivation to fix it: pending.";
 
   return (
     <div

--- a/src/shared/ui/theme/theme-provider.tsx
+++ b/src/shared/ui/theme/theme-provider.tsx
@@ -7,19 +7,17 @@ export interface ProvidersProps {
   children: React.ReactNode;
 }
 
-/** The three mutually-exclusive themes. neo extends dark (it boots `.dark` +
- *  `.neo`); a theme is exclusive by nature, so neo is a third theme, not a
- *  "mode that forces dark". */
-export type Theme = "light" | "dark" | "neo";
+/** The two themes. */
+export type Theme = "light" | "dark";
 
-const THEMES: readonly Theme[] = ["light", "dark", "neo"] as const;
+const THEMES: readonly Theme[] = ["light", "dark"] as const;
 
 interface ThemeContextType {
   theme: Theme;
   setTheme: (theme: Theme) => void;
-  /** light → dark → neo → light. */
+  /** light → dark → light. */
   cycleTheme: () => void;
-  /** Derived: dark OR neo (neo extends the dark canvas). */
+  /** Derived: the dark canvas. */
   isDarkTheme: boolean;
 }
 
@@ -34,23 +32,17 @@ export const useTheme = () => {
 };
 
 /** Read the theme already applied to `<html>` (the pre-paint inline script +
- *  `ThemeProvider` both set the `.dark`/`.neo` classes). SSR-safe: `"light"`
- *  when there's no document. */
+ *  `ThemeProvider` both set the `.dark` class). SSR-safe: `"light"` when there's
+ *  no document. */
 function readAppliedTheme(): Theme {
   if (typeof document === "undefined") return "light";
-  const html = document.documentElement;
-  return html.classList.contains("neo")
-    ? "neo"
-    : html.classList.contains("dark")
-      ? "dark"
-      : "light";
+  return document.documentElement.classList.contains("dark") ? "dark" : "light";
 }
 
 /**
  * Like {@link useTheme} but NEVER throws — for fallback UIs that can render
- * ABOVE or OUTSIDE the `ThemeProvider` (the root `ErrorBoundary` fallback, which
- * sits above the provider). Returns the provider value when present, else reads
- * the theme straight off `<html>` so the copy still matches the active theme.
+ * ABOVE or OUTSIDE the `ThemeProvider` (the root `ErrorBoundary` fallback).
+ * Returns the provider value when present, else reads the theme off `<html>`.
  */
 export const useThemeSafe = (): Pick<
   ThemeContextType,
@@ -61,39 +53,28 @@ export const useThemeSafe = (): Pick<
     return { theme: context.theme, isDarkTheme: context.isDarkTheme };
   }
   const theme = readAppliedTheme();
-  return { theme, isDarkTheme: theme !== "light" };
+  return { theme, isDarkTheme: theme === "dark" };
 };
 
 /**
  * Apply the theme to `<html>` — the single source the CSS tokens key off:
- * `data-theme` (completeness) + the `.dark` / `.neo` classes. light = neither;
- * dark = `.dark`; neo = `.dark` + `.neo` (neo extends the dark tokens with the
- * rain/translucency layer). The same is done pre-paint by the inline script in
- * the root layout, so the first paint is already the right theme (no flash).
+ * `data-theme` + the `.dark` class. light = neither; dark = `.dark`. The same is
+ * done pre-paint by the inline script in the root layout (no flash).
  */
 function applyTheme(theme: Theme) {
   const html = document.documentElement;
   html.setAttribute("data-theme", theme);
-  html.classList.toggle("dark", theme === "dark" || theme === "neo");
-  html.classList.toggle("neo", theme === "neo");
+  html.classList.toggle("dark", theme === "dark");
 }
 
 export function ThemeProvider({ children }: ProvidersProps) {
   const [theme, setThemeState] = useState<Theme>("light");
 
   // The inline script already resolved + applied the theme to <html> before
-  // paint; sync React state to it so consumers (the cycling control, the
-  // derived `isDarkTheme`) match without driving the visual theme (which
-  // <html> already carries).
+  // paint; sync React state to it so consumers match without re-driving paint.
   useEffect(() => {
-    const html = document.documentElement;
-    const applied: Theme = html.classList.contains("neo")
-      ? "neo"
-      : html.classList.contains("dark")
-        ? "dark"
-        : "light";
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setThemeState(applied);
+    setThemeState(readAppliedTheme());
   }, []);
 
   const setTheme = (next: Theme) => {
@@ -111,7 +92,7 @@ export function ThemeProvider({ children }: ProvidersProps) {
     theme,
     setTheme,
     cycleTheme,
-    isDarkTheme: theme !== "light",
+    isDarkTheme: theme === "dark",
   };
 
   return (

--- a/src/shared/ui/theme/tokens.css
+++ b/src/shared/ui/theme/tokens.css
@@ -56,14 +56,16 @@
 /* `.dark` now lives on <html> (layout inline script + ThemeProvider), so this
    reaches page scopes AND body-level portals (toasts, modals) alike.
    `--m-card`/`--m-panel` are TRANSLUCENT (the dark #232323 / #2a2a2a at 0.70
-   alpha): composited over the opaque `--m-bg #141414` they read a touch DARKER
-   than a solid fill (~#1e1e1e / ~#232323), so every card/band sinks INTO the
-   canvas instead of sitting on top of it. `--m-bg` stays opaque (the dropdown
-   console + modals use `bg-[var(--m-bg)]`, so they stay fully solid); overlays
-   reset to solid below. */
+   alpha): composited over the opaque `--m-bg #181818` they read a touch DARKER
+   than a solid fill (~#1f1f1f / ~#242424), so every card/band sinks INTO the
+   canvas instead of sitting on top of it. `--m-bg` is a hair above pitch black
+   (#181818, not #141414) so the canvas reads as an intentional charcoal that
+   harmonizes with the lime accent rather than pure black. `--m-bg` stays opaque
+   (the dropdown console + modals use `bg-[var(--m-bg)]`, so they stay fully
+   solid); overlays reset to solid below. */
 .dark .mono-scope,
 .dark .mono-portal {
-  --m-bg: #141414;
+  --m-bg: #181818;
   --m-fg: #dcdcdc;
   --m-accent: #cdff48;
   --m-line: #e6e6e6;

--- a/src/shared/ui/theme/tokens.css
+++ b/src/shared/ui/theme/tokens.css
@@ -58,11 +58,9 @@
    `--m-card`/`--m-panel` are TRANSLUCENT (the dark #232323 / #2a2a2a at 0.70
    alpha): composited over the opaque `--m-bg #141414` they read a touch DARKER
    than a solid fill (~#1e1e1e / ~#232323), so every card/band sinks INTO the
-   canvas instead of sitting on top of it — the look that already shipped in neo,
-   now the baseline for dark too. `--m-bg` stays opaque (the dropdown console +
-   modals use `bg-[var(--m-bg)]`, so they stay fully solid); overlays reset to
-   solid below. neo (whose <html> also carries `.dark`) inherits all of this and
-   only adds the rain bleed. */
+   canvas instead of sitting on top of it. `--m-bg` stays opaque (the dropdown
+   console + modals use `bg-[var(--m-bg)]`, so they stay fully solid); overlays
+   reset to solid below. */
 .dark .mono-scope,
 .dark .mono-portal {
   --m-bg: #141414;
@@ -81,21 +79,10 @@
    (`role="listbox"`) and the editor (`.milkdown` — toolbar + popovers read
    `--m-card`/`--m-panel` directly or via `--crepe-color-surface`). Content
    scrolls behind them, so the translucency turns their text unreadable. Reset
-   the surface tokens to their SOLID dark values. Applies to dark AND neo (neo's
-   <html> also carries `.dark`). */
+   the surface tokens to their SOLID dark values. */
 html.dark [role="menu"],
 html.dark [role="listbox"],
 html.dark .milkdown {
   --m-card: #232323;
   --m-panel: #2a2a2a;
-}
-
-/* neo — the third theme ("Matrix"). It is the dark theme PLUS the rain: neo
-   always boots `.dark` + `.neo` (set pre-paint), so it inherits the dark tokens
-   above (incl. the translucent card/panel) and only drops the page-root bg to
-   transparent so the fixed Matrix-rain drape bleeds through the whole canvas.
-   The header wrapper is also a `.mono-scope` but carries no bg, so that's a
-   no-op there. */
-html.neo .mono-scope {
-  background-color: transparent;
 }

--- a/src/widgets/header/header.tsx
+++ b/src/widgets/header/header.tsx
@@ -6,7 +6,7 @@ import { motion } from "framer-motion";
 import { useClickOutside } from "react-haiku";
 import { Bars3Icon } from "@heroicons/react/24/solid";
 import { prefersReducedMotion } from "@/shared/lib/prefers-reduced-motion";
-import { useTheme } from "@/shared/providers/theme-providers";
+import { useTheme } from "@/shared/ui/theme";
 import { useUser, useAuth } from "@/entities/session";
 import { AuthModal } from "@/features/auth/ui/auth-modal";
 import { RabbitMark } from "@/features/arcade/snake";
@@ -40,18 +40,16 @@ export function Header() {
           the 1240 content column). */}
       <header className="fixed inset-x-0 top-0 z-[var(--m-z-header)] h-[var(--m-header-h)] border-b-2 border-[var(--m-card)] bg-[var(--m-bg)]/70 backdrop-blur-md">
         <div className="flex h-full items-center justify-between px-5">
-          {/* Lockup + the hidden NEO easter-egg: the game's white rabbit sits
-              right AFTER the lockup's blinking cursor (a `ml-3` = 12px gap, one
-              step up the scale from the cursor), ONLY in the neo theme AND only
-              when signed in — "follow the white rabbit" to the arcade (which is
-              login-only, so there's no point dangling it to logged-out visitors).
-              On hover/focus it `mono-jiggle`s (a playful "laughing" wobble;
-              transform-only, no layout shift, dropped under reduced-motion).
-              Hidden under `sm` so it never crowds / wraps the wordmark on a
-              narrow phone bar. Not on light/dark. */}
+          {/* Lockup + the game's white rabbit: it sits right AFTER the lockup's
+              blinking cursor (a `ml-3` = 12px gap), shown when signed in — the
+              link into the arcade (which is login-only, so there's no point
+              dangling it to logged-out visitors). On hover/focus it
+              `mono-jiggle`s (a playful "laughing" wobble; transform-only, no
+              layout shift, dropped under reduced-motion). Hidden under `sm` so it
+              never crowds / wraps the wordmark on a narrow phone bar. */}
           <div className="flex items-center">
             <HeaderLockup />
-            {theme === "neo" && isAuthenticated && (
+            {isAuthenticated && (
               <Link
                 href="/arcade/follow-the-rabbit"
                 aria-label="Follow the white rabbit"

--- a/src/widgets/header/header.tsx
+++ b/src/widgets/header/header.tsx
@@ -55,7 +55,11 @@ export function Header() {
                 aria-label="Follow the white rabbit"
                 className="mono-jiggle mono-focus ml-3 hidden shrink-0 opacity-80 transition-opacity hover:opacity-100 focus-visible:opacity-100 sm:inline-flex"
               >
-                <RabbitMark size={16} className="mono-jiggle__mark" />
+                <RabbitMark
+                  size={16}
+                  fill={theme === "light" ? "var(--m-error)" : undefined}
+                  className="mono-jiggle__mark"
+                />
               </Link>
             )}
           </div>

--- a/src/widgets/header/settings-toggles.tsx
+++ b/src/widgets/header/settings-toggles.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import type { Theme } from "@/shared/providers/theme-providers";
+import type { Theme } from "@/shared/ui/theme";
 import { CommandButton } from "./command-row";
 
 /** Bracketed `[ value ]` indicator on the right of a settings toggle row. */
@@ -33,10 +33,8 @@ interface SettingsTogglesProps {
  * the menu open so the user can flip it in place. (The lang toggle is HIDDEN for
  * now — i18n is a backlog item; re-add the row here when wiring i18n.)
  *
- * `theme` is a single cycling control (light → dark → neo → light) — a theme is
- * mutually-exclusive by nature, so neo is just a third theme value here, not a
- * separate toggle. The indicator is accent whenever the canvas is dark
- * (dark/neo), muted on light.
+ * `theme` is a single cycling control (light → dark → light). The indicator is
+ * accent on dark, muted on light.
  */
 export function SettingsToggles({
   open,


### PR DESCRIPTION
## Themes
- `theme-provider`: `Theme = light | dark`, cycle light↔dark, `isDark = dark`.
- Drop the `.neo` class, neo tokens, the ambient matrix-rain backdrop (`.mono-rain-bg`), and the neo branch of the inline pre-paint script — across `tokens.css`, `tailwind.css`, `global.scss`, `layout.tsx`, `settings-toggles`.
- Drop the `@/shared/providers/theme-providers` shim — consumers import `@/shared/ui/theme` directly.
- **Dark canvas** `#141414` → `#181818` (a hair lighter — an intentional charcoal that frames the lime accent), matched across tokens / global.scss / global-error / the `/brand` swatch.

## Error page & arcade
- Error/404: drop the neo "The matrix has you / Follow the white rabbit / Knock knock Neo" variant → always the generic "A glitch in the Lazyverse".
- Arcade: remove the "You are not the One" reject gag + the neo gating — Snake is **login-only and open to any theme**; "// GAME OVER".
- Header **white-rabbit** shows on light + dark (when signed in); it turns **red** (`var(--m-error)`) on the light theme so it reads on the light canvas.
- Snake body is now a stream of solid **squares** (no churning glyphs) — accent-green head, dimming + fading toward a still-readable tail; ~25% smaller cells.

## /brand
- Text FX (GlitchText / MatrixText) demo moved to the **Components** tab.
- The glyph-rain experiments get their own **Glyph Rain** tab (+ a Fullscreen takeover per effect); the Lab keeps the Matrix-rain canvas + post-FX.